### PR TITLE
Replace single job with multiple stages for azure pipelines

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,14 @@
 name: test
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'test/azure-pipelines/**'
+      - 'azure-pipelines.yml'
+  pull_request:
+    paths-ignore:
+      - 'test/azure-pipelines/**'
+      - 'azure-pipelines.yml'
 
 jobs:
   test:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,6 @@
 stages:
   - stage:
-    displayName: Test and Build on Windows
+    displayName: On Windows
     pool:
       vmImage: windows-latest
     jobs:
@@ -8,7 +8,9 @@ stages:
         steps:
           - template: test/azure-pipelines/win32/azure-pipelines.yml
   - stage:
-    displayName: Test and Build on Linux
+    displayName: On Linux
+    # Removes the implicit dependency and run in paralle
+    dependsOn: []
     pool:
       vmImage: ubuntu-latest
     jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,20 +1,22 @@
-jobs:
-- job: Windows
-  pool:
-    vmImage: windows-latest
-  steps:
-  - template: test/azure-pipelines/win32/azure-pipelines.yml
-- job: Linux
-  pool:
-    vmImage: ubuntu-latest
-  steps:
-  - template: test/azure-pipelines/linux/azure-pipelines.yml
-- job: Docker
-  pool:
-    vmImage: ubuntu-latest
-  dependsOn: Linux
-  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
-  variables:
-  - group: docker
-  steps:
-  - template: test/azure-pipelines/docker/azure-pipelines.yml
+stages:
+  - stage:
+    displayName: Test and Build on Windows
+    pool:
+      vmImage: windows-latest
+    jobs:
+      - job: Windows
+        steps:
+          - template: test/azure-pipelines/win32/azure-pipelines.yml
+  - stage:
+    displayName: Test and Build on Linux
+    pool:
+      vmImage: ubuntu-latest
+    jobs:
+      - job: Linux
+        steps:
+          - template: test/azure-pipelines/linux/azure-pipelines.yml
+      - job: Docker
+        dependsOn: Linux
+        condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+        steps:
+          - template: test/azure-pipelines/docker/azure-pipelines.yml

--- a/test/azure-pipelines/docker/azure-pipelines.yml
+++ b/test/azure-pipelines/docker/azure-pipelines.yml
@@ -1,14 +1,14 @@
 steps:
-- script: |
-    docker pull golang:alpine || true
-    docker pull alpine:latest || true
-  displayName: Fetche Ltest Image
-- script: |
-    docker build --no-cache -t $(DOCKER_USER)/fyj:latest .
-  displayName: Build Docker Image
-- script: |
-    echo -n $(DOCKER_TOKEN) | docker login -u $(DOCKER_USER) --password-stdin
-  displayName: Login Docker Hub
-- script: |
-    docker push $(DOCKER_USER)/fyj:latest
-  displayName: Push Docker Image
+  - script: |
+      docker pull golang:alpine || true
+      docker pull alpine:latest || true
+    displayName: Fetche Ltest Image
+  - script: |
+      docker build --no-cache -t $(DOCKER_USER)/fyj:latest .
+    displayName: Build Docker Image
+  - script: |
+      echo -n $(DOCKER_TOKEN) | docker login -u $(DOCKER_USER) --password-stdin
+    displayName: Login Docker Hub
+  - script: |
+      docker push $(DOCKER_USER)/fyj:latest
+    displayName: Push Docker Image

--- a/test/azure-pipelines/linux/azure-pipelines.yml
+++ b/test/azure-pipelines/linux/azure-pipelines.yml
@@ -1,18 +1,18 @@
 steps:
-- task: GoTool@0
-  inputs:
-    version: '1.16.2'
-- script: |
-    go mod download
-    cp src/config/example.ini ~/fyj.ini
-    make test
-  displayName: Run Tests
-- script: |
-    make
-    make web
-  displayName: Build and Compile
-- task: PublishBuildArtifacts@1
-  inputs:
-    pathtoPublish: build
-    artifactName: linux-amd64
-  displayName: Publish Build Artifacts
+  - task: GoTool@0
+    inputs:
+      version: '1.16.2'
+  - script: |
+      go mod download
+      cp src/config/example.ini ~/fyj.ini
+      make test
+    displayName: Run Tests
+  - script: |
+      make
+      make web
+    displayName: Build and Compile
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathtoPublish: build
+      artifactName: linux-amd64
+    displayName: Publish Build Artifacts

--- a/test/azure-pipelines/win32/azure-pipelines.yml
+++ b/test/azure-pipelines/win32/azure-pipelines.yml
@@ -1,24 +1,24 @@
 steps:
-- task: GoTool@0
-  inputs:
-    version: '1.16.2'
-- powershell: |
-    choco install make -y
-  displayName: Install Make Tool
-- powershell: |
-    go mod download
-    Copy-Item -Path .\src\config\example.ini -Destination ~\fyj.ini
-    make test
-  displayName: Run Tests
-- script: |
-    make
-    make web
-  displayName: Build and Compile
-- script: |
-    iscc .\script\windows\go-xn.iss
-  displayName: Build Inno Setup Installer
-- task: PublishBuildArtifacts@1
-  inputs:
-    pathtoPublish: build\dist
-    artifactName: windows-amd64
-  displayName: Publish Build Artifacts
+  - task: GoTool@0
+    inputs:
+      version: '1.16.2'
+  - powershell: |
+      choco install make -y
+    displayName: Install Make Tool
+  - powershell: |
+      go mod download
+      Copy-Item -Path .\src\config\example.ini -Destination ~\fyj.ini
+      make test
+    displayName: Run Tests
+  - script: |
+      make
+      make web
+    displayName: Build and Compile
+  - script: |
+      iscc .\script\windows\go-xn.iss
+    displayName: Build Inno Setup Installer
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathtoPublish: build\dist
+      artifactName: windows-amd64
+    displayName: Publish Build Artifacts


### PR DESCRIPTION
- Ignore azure-pipelines-related paths for `push` and `pull_request` events for `Github Actions`.
- Replace single job with multiple stages for `Azure Pipelines`.
  * Divide existing jobs into multiple stages for azure pipelines ci.
  * Format azure-pipelines yaml files by specification.
- Removes the implicit `dependsOn` and update `displayName`.
  * Add `dependsOn: []`, this removes the implicit dependency on previous stage and causes this to run in parallel.
  * Update `displayName` for stages.