### PR TITLE
Update log files path and its writer buffer

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"os"
+	"path/filepath"
 
 	"github.com/go-ini/ini"
 
@@ -21,12 +21,10 @@ func init() {
 }
 
 func defaultConfigPath() string {
-	ps := string(os.PathSeparator)
-
 	files := []string{
 		"fyj.ini",
-		home.HomeDir() + ps + ".config" + ps + "fyj" + ps + "fyj.ini",
-		home.HomeDir() + ps + "fyj.ini",
+		filepath.Join(home.ConfigDir("fyj"), "fyj.ini"), // ~/.config/fyj/fyj.ini
+		filepath.Join(home.HomeDir(), "fyj.ini"),        // ~/fyj.ini
 	}
 	for _, f := range files {
 		if file.IsExist(f) && file.IsFile(f) {

--- a/src/middleware/logger.go
+++ b/src/middleware/logger.go
@@ -4,34 +4,25 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/Pengxn/go-xn/src/util/file"
+	"github.com/Pengxn/go-xn/src/util/home"
 	"github.com/Pengxn/go-xn/src/util/log"
 )
 
 func Logger() gin.HandlerFunc {
 	return gin.LoggerWithConfig(gin.LoggerConfig{
-		Formatter: CustomLog,
-		Output:    WriterLog(),
+		Formatter: customLog,
+		Output:    writerLog(),
 	})
 }
 
-// WriterLog writes log to the specified writer buffer.
-// Example: os.Stdout, a file opened in write mode, a socket...
-func WriterLog() io.Writer {
-	// Logging to a file, append logging if the file already exists.
-	f, err := os.OpenFile("fyj.log", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
-	if err != nil {
-		log.Errorf("Create log file error: %v", err)
-	}
-
-	return io.MultiWriter(f, os.Stdout)
-}
-
-// CustomLog is the custom log format function Logger middleware uses.
-func CustomLog(param gin.LogFormatterParams) string {
+// customLog is the custom log format function Logger middleware uses.
+func customLog(param gin.LogFormatterParams) string {
 	var statusColor, methodColor, resetColor string
 	if param.IsOutputColor() {
 		statusColor = param.StatusCodeColor()
@@ -51,4 +42,31 @@ func CustomLog(param gin.LogFormatterParams) string {
 		param.Path,
 		param.ErrorMessage,
 	)
+}
+
+// writerLog writes log to the specified writer buffer.
+// Example: os.Stdout, a file opened in write mode, a socket...
+func writerLog() io.Writer {
+	logFile := "route.log"
+	if !file.IsExist(logFile) {
+		logDir := filepath.Join(home.LogDir("fyj"), "logs")
+		if file.IsExist(logDir) {
+			logFile = filepath.Join(logDir, logFile)
+		} else {
+			if err := os.MkdirAll(logDir, 0755); err != nil {
+				log.Errorf("Mkdir folder %s error: %+v", logDir, err)
+			} else {
+				logFile = filepath.Join(logDir, logFile)
+			}
+		}
+	}
+
+	// Logging to a file, append logging if the file already exists.
+	f, err := os.OpenFile(logFile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
+	if err != nil {
+		log.Errorf("Open log file %s error: %+v", logFile, err)
+		return os.Stdout
+	}
+
+	return io.MultiWriter(f, os.Stdout)
 }

--- a/src/util/log/log.go
+++ b/src/util/log/log.go
@@ -8,6 +8,9 @@ var logger *logrus.Logger
 
 func init() {
 	logger = logrus.New()
+
+	logger.SetLevel(logrus.DebugLevel)
+	logger.SetOutput(writerLog())
 }
 
 // Error logs a message at level Error.

--- a/src/util/log/writer.go
+++ b/src/util/log/writer.go
@@ -1,0 +1,38 @@
+package log
+
+import (
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/Pengxn/go-xn/src/util/file"
+	"github.com/Pengxn/go-xn/src/util/home"
+)
+
+// writerLog writes log to the specified writer buffer.
+// Example: os.Stderr, a file opened in write mode, a socket...
+func writerLog() io.Writer {
+	logFile := "fyj.log"
+	if !file.IsExist(logFile) {
+		logDir := filepath.Join(home.LogDir("fyj"), "logs")
+		if file.IsExist(logDir) {
+			logFile = filepath.Join(logDir, logFile)
+		} else {
+			if err := os.MkdirAll(logDir, 0755); err != nil {
+				log.Printf("Mkdir folder %s error: %+v", logDir, err)
+			} else {
+				logFile = filepath.Join(logDir, logFile)
+			}
+		}
+	}
+
+	// Logging to a file, append logging if the file already exists.
+	f, err := os.OpenFile(logFile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
+	if err != nil {
+		log.Printf("Open log file %s error: %+v", logFile, err)
+		return os.Stderr
+	}
+
+	return io.MultiWriter(f, os.Stderr)
+}

--- a/web/embed.go
+++ b/web/embed.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"embed"
+	"fmt"
 	"html/template"
 	"io/fs"
 	"net/http"
@@ -21,9 +22,9 @@ func HTML() *template.Template {
 		log.Errorf("template.ParseFS error: %+v", err)
 	}
 
-	if !gin.IsDebugging() {
+	if gin.IsDebugging() {
 		for _, tmpl := range t.Templates() {
-			log.Info(tmpl.Name())
+			fmt.Println(tmpl.Name())
 		}
 	}
 


### PR DESCRIPTION
- Disable print information about templates in non-debug mode.
- Use `home.ConfigDir` and `filepath.Join` to get the log file path.
- Handle log files path and its writer buffer.