### PR TITLE
Add `/dav` route to serve WebDAV

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/tidwall/gjson v1.14.4
 	github.com/urfave/cli/v2 v2.25.3
 	github.com/yuin/goldmark v1.5.4
-	golang.org/x/net v0.10.0
+	golang.org/x/net v0.17.0
 	xorm.io/xorm v1.3.2
 )
 
@@ -70,10 +70,10 @@ require (
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	golang.org/x/arch v0.3.0 // indirect
-	golang.org/x/crypto v0.9.0 // indirect
-	golang.org/x/sys v0.8.0 // indirect
-	golang.org/x/term v0.8.0 // indirect
-	golang.org/x/text v0.9.0 // indirect
+	golang.org/x/crypto v0.14.0 // indirect
+	golang.org/x/sys v0.13.0 // indirect
+	golang.org/x/term v0.13.0 // indirect
+	golang.org/x/text v0.13.0 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
 	gopkg.in/mail.v2 v2.3.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/tidwall/gjson v1.14.4
 	github.com/urfave/cli/v2 v2.25.3
 	github.com/yuin/goldmark v1.5.4
+	golang.org/x/net v0.10.0
 	xorm.io/xorm v1.3.2
 )
 
@@ -70,7 +71,6 @@ require (
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	golang.org/x/arch v0.3.0 // indirect
 	golang.org/x/crypto v0.9.0 // indirect
-	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/term v0.8.0 // indirect
 	golang.org/x/text v0.9.0 // indirect

--- a/src/controller/webdav.go
+++ b/src/controller/webdav.go
@@ -1,0 +1,30 @@
+package controller
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"golang.org/x/net/webdav"
+
+	"github.com/Pengxn/go-xn/src/util/log"
+)
+
+// WebdavMethods is a list of supported WebDAV methods.
+var WebdavMethods = []string{
+	"OPTIONS", "GET", "HEAD", "POST", "DELETE", "PUT",
+	"MKCOL", "COPY", "MOVE", "LOCK", "UNLOCK", "PROPFIND", "PROPPATCH",
+}
+
+func WebDAV(c *gin.Context) {
+	h := webdav.Handler{
+		Prefix:     "/dav",
+		FileSystem: webdav.Dir("data/webdav"),
+		LockSystem: webdav.NewMemLS(),
+		Logger: func(r *http.Request, err error) {
+			if err != nil {
+				log.Errorf("[WebDAV] %s => %s error: %v", r.Method, r.URL.Path, err)
+			}
+		},
+	}
+	h.ServeHTTP(c.Writer, c.Request)
+}

--- a/src/route/others.go
+++ b/src/route/others.go
@@ -15,6 +15,11 @@ func othersRoutes(g *gin.Engine) {
 	// JSON Feed Version 1, https://jsonfeed.org/version/1
 	g.GET("/feed", controller.Feed)
 
+	// WebDAV, server for WebDAV service.
+	for _, v := range controller.WebdavMethods {
+		g.Handle(v, "/dav/*webdav", controller.WebDAV)
+	}
+
 	g.GET("/md", controller.Mdcat)
 
 	// Get domain whois information.


### PR DESCRIPTION
1. Register `/dav` route to handle WebDAV requests.
2. Bump `golang.org/x/net` package to 0.17.0, to resolve 3 dependabot alerts. #204