### PR TITLE
Bump actions/checkout to `v4`

### DIFF
--- a/.github/workflows/test.docker.yml
+++ b/.github/workflows/test.docker.yml
@@ -7,7 +7,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Fetche Latest Image
         run: |

--- a/.github/workflows/test.linux.yml
+++ b/.github/workflows/test.linux.yml
@@ -7,7 +7,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Go
         uses: actions/setup-go@v4

--- a/.github/workflows/test.windows.yml
+++ b/.github/workflows/test.windows.yml
@@ -7,7 +7,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Go
         uses: actions/setup-go@v4


### PR DESCRIPTION
Bumps `actions/checkout` to `v4`, use node 20 as default runtime.
All actions will be transitioned to use node 20 runtime by Spring 2024, refer to:
- https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
- https://github.com/actions/checkout/releases/tag/v4.0.0