### PR TITLE
Build multi-arch image with buildx and update github actions

### DIFF
--- a/.github/workflows/test.docker.yml
+++ b/.github/workflows/test.docker.yml
@@ -14,9 +14,13 @@ jobs:
           docker pull golang:alpine || true
           docker pull alpine:latest || true
 
-      - name: Build Docker Image
-        run: |
-          docker build --no-cache -t fyj:latest .
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       # Docker Hub
       - name: Login Docker Hub
@@ -24,10 +28,6 @@ jobs:
         with:
           username: ${{ vars.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
-      - name: Push to Docker Hub
-        run: |
-          docker tag fyj:latest ${{ vars.DOCKER_USER }}/fyj:latest
-          docker push ${{ vars.DOCKER_USER }}/fyj:latest
 
       # GitHub Container registry (ghcr.io)
       - name: Login GitHub Container
@@ -39,7 +39,13 @@ jobs:
       - name: Set GCHR_USER Environment Variable
         run: |
           echo "GCHR_USER=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
-      - name: Push to GitHub Container
-        run: |
-          docker tag fyj:latest ghcr.io/${{ env.GCHR_USER }}/fyj:latest
-          docker push ghcr.io/${{ env.GCHR_USER }}/fyj:latest
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ vars.DOCKER_USER }}/fyj:latest
+            ghcr.io/${{ env.GCHR_USER }}/fyj:latest

--- a/.github/workflows/test.docker.yml
+++ b/.github/workflows/test.docker.yml
@@ -20,7 +20,7 @@ jobs:
 
       # Docker Hub
       - name: Login Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
@@ -31,7 +31,7 @@ jobs:
 
       # GitHub Container registry (ghcr.io)
       - name: Login GitHub Container
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,6 @@ jobs:
 
   deploy-docker:
     needs: test-linux
-    # if: github.event_name == 'push' && github.ref_name == 'main'
+    if: github.event_name == 'push' && github.ref_name == 'main'
     uses: ./.github/workflows/test.docker.yml
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,6 @@ jobs:
 
   deploy-docker:
     needs: test-linux
-    if: github.event_name == 'push' && github.ref_name == 'main'
+    # if: github.event_name == 'push' && github.ref_name == 'main'
     uses: ./.github/workflows/test.docker.yml
     secrets: inherit


### PR DESCRIPTION
- Bump `docker/login-action` to `v3`.[^1]
- Add `docker/setup-qemu-action@v3`[^2], `docker/setup-buildx-action@v3`[^3] and `docker/build-push-action@v5`[^4] actions.
- Build multi-arch docker image on GitHub Actions with [buildx](https://github.com/docker/buildx).

[^1]: [docker/login-action `v3` release](https://github.com/docker/login-action/releases/tag/v3.0.0), use node 20 as default runtime
[^2]: [setup-qemu-action](https://github.com/docker/setup-qemu-action/tree/v3): install QEMU static binaries
[^3]: [setup-buildx-action](https://github.com/docker/setup-buildx-action/tree/v3): set up docker buildx
[^4]: [build-push-action](https://github.com/docker/build-push-action/tree/v5): build and push docker images with build