### PR TITLE
Update go version to `1.12`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	xorm.io/xorm v1.3.4
 )
 
-go 1.20
+go 1.21
 
 require (
 	github.com/boombuler/barcode v1.0.1 // indirect

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-//go:build go1.18
+//go:build go1.21
 
 // Copyright 2020 The Go-xn Authors. All rights reserved.
 // Use of this source code is governed by a Zlib license


### PR DESCRIPTION
1. Upgrade the minimum go version implied by the build constraints tag expression[^1] to 1.21 as in go.mod file.
2. Upgrade minimum go version to 1.21 in go.mod file.

The go.mod file is modified to the following text after running `go mod tidy`[^2].

```diff
-go.1.20
+go 1.21
+
+toolchain go1.21.4
```

The cause of the above problem is determined to be the last updated [webauthn](https://github.com/go-webauthn/webauthn) package. [^3]
The minimum version of go required to compile packages in `github.com/go-webauthn/webauthn` module is set to `1.21`. [^4]

[^1]: [go build constraints](https://go.dev/design/draft-gobuild)
[^2]: [go.mod file reference](https://go.dev/doc/modules/gomod-ref#go) and [Go Modules Reference # go mod tidy](https://go.dev/ref/mod#go-mod-tidy) and https://go.dev/ref/mod#go-mod-file-go
[^3]: commit hash e69734f9bd42d24d53a92f030197cc615cebc16d
[^4]: https://github.com/go-webauthn/webauthn/commit/9322e17a1c699c927eacb2d48633f95212dca031