### PR TITLE
Fix build docker with sqlite3 musl error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,6 @@ jobs:
 
   deploy-docker:
     needs: test-linux
-    # if: github.event_name == 'push' && github.ref_name == 'main'
+    if: github.event_name == 'push' && github.ref_name == 'main'
     uses: ./.github/workflows/test.docker.yml
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,6 @@ jobs:
 
   deploy-docker:
     needs: test-linux
-    if: github.event_name == 'push' && github.ref_name == 'main'
+    # if: github.event_name == 'push' && github.ref_name == 'main'
     uses: ./.github/workflows/test.docker.yml
     secrets: inherit

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY . .
 RUN apk add --no-cache build-base make git; \
     go mod download; \
     go mod tidy; \
-    make
+    CGO_CFLAGS="-D_LARGEFILE64_SOURCE" make
 
 # Server image
 FROM alpine:latest


### PR DESCRIPTION
Fix build docker error in [github actions job#923](https://github.com/Pengxn/go-xn/actions/runs/7150953695/job/19622614044#step:9:328).

This is now broken in latest `golang:alpine` image (from alpine3.18 to alpine3.19).
Alpine 3.19 was released on 2023-12-07.[^1] It is shipped with gcc 13.2 and musl-dev 2.14.[^2]
The LFS64 interfaces were marked as deprecated for musl 1.2.4.[^3]

As a temporary workaround, builds broken by this change can be fixed short-term by adding `-D_LARGEFILE64_SOURCE` to `CFLAGS`, but should be fixed to use the standard interfaces, refer to [go-sqlite3 issue#1164](https://github.com/mattn/go-sqlite3/issues/1164).

[^1]: [Alpine 3.19.0 release note](https://www.alpinelinux.org/posts/Alpine-3.19.0-released.html)
[^2]: [Package musl-dev](https://pkgs.alpinelinux.org/packages?name=musl-dev&branch=v3.19)
[^3]: [musl git commit: remove LFS64 programming interfaces (macro-only) from _GNU_SOURCE](https://git.musl-libc.org/cgit/musl/commit/?id=25e6fee27f4a293728dd15b659170e7b9c7db9bc)