### PR TITLE
Revert the commit because of upgrading go-sqlite3 to `1.14.19`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,6 @@ jobs:
 
   deploy-docker:
     needs: test-linux
-    if: github.event_name == 'push' && github.ref_name == 'main'
+    if: github.event_name == 'push' # && github.ref_name == 'main'
     uses: ./.github/workflows/test.docker.yml
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,6 @@ jobs:
 
   deploy-docker:
     needs: test-linux
-    if: github.event_name == 'push' # && github.ref_name == 'main'
+    if: github.event_name == 'push' && github.ref_name == 'main'
     uses: ./.github/workflows/test.docker.yml
     secrets: inherit

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY . .
 RUN apk add --no-cache build-base make git; \
     go mod download; \
     go mod tidy; \
-    CGO_CFLAGS="-D_LARGEFILE64_SOURCE" make
+    make
 
 # Server image
 FROM alpine:latest


### PR DESCRIPTION
Revert `Fix build docker with sqlite3 musl error (#234)`

The commit 031e41a is a temporary workaround to fix musl build error.
Remove `CGO_CFLAGS="-D_LARGEFILE64_SOURCE"` for building docker image.
Because go-sqlite3 library was upgraded to `1.14.19`[^1] and the musl build was fixed in go-sqlite3 version `1.14.19`[^2].

This reverts commit 031e41af61120c09acd4b980d8754859f5a30182 (refer PR #234).

[^1]: commit hash ad6673b0b359f4c9680aa9b5d7abe860a7d10bd7
[^2]: [mattn/go-sqlite3#1177](https://github.com/mattn/go-sqlite3/pull/1177)