### PR TITLE
Use `.git-blame-ignore-revs` file to ignore certain commits

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,7 @@
+# refer to https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view
+
+# To use this file (requires git 2.23):
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# typo in commit main message
+892b9baa5e38f975a7a2eace8af738a2fabd5baa


### PR DESCRIPTION
Create `.git-blame-ignore-revs` file, and use it as default `blame.ignoreRevsFile`.

Run the following command to use this file (requires git 2.23):
```shell
git config blame.ignoreRevsFile .git-blame-ignore-revs
```

Append commit 892b9baa5e38f975a7a2eace8af738a2fabd5baa to `.git-blame-ignore-revs` file to hide it from the blame view, because the commit main message has a typo[^1].

For the file refer to `GitHub Docs #Ignore commits in the blame view`[^2] and `git doc #git-config`[^3].

[^1]: [comment on commit `892b9ba`](https://github.com/Pengxn/go-xn/commit/892b9baa5e38f975a7a2eace8af738a2fabd5baa#commitcomment-134639097)
[^2]: [GitHub Docs #Ignore commits in the blame view](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view)
[^3]: [git doc #git-config](https://git-scm.com/docs/git-config#Documentation/git-config.txt-blameignoreRevsFile)