### PR TITLE
Refactor `Makefile` with verbose output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,9 @@
 # Make sure you install `make` and `git` tool
 
-# OS=Windows_NT for git-bash on Windows OS
-ifeq ($(OS), Windows_NT)
-	BIN = go-xn.exe
-else
-	BIN = go-xn
+BIN  = go-xn
+GOOS = $(shell go env GOOS)
+ifeq ($(GOOS), windows)
+	BIN := go-xn.exe
 endif
 
 VERSION     = $(shell git describe --tags `git rev-list --tags --max-count=1`)

--- a/Makefile
+++ b/Makefile
@@ -7,17 +7,17 @@ else
 	BIN = go-xn
 endif
 
-VERSION = $(shell git describe --tags `git rev-list --tags --max-count=1`)
-COMMIT_ID = $(shell git rev-parse --short HEAD)
-BUILD_TIME = $(shell date +'%Y-%m-%d %T')
-LDFLAGS += -X "github.com/Pengxn/go-xn/src/cmd.Version=${VERSION}"
-LDFLAGS += -X "github.com/Pengxn/go-xn/src/cmd.commitID=${COMMIT_ID}"
-LDFLAGS += -X "github.com/Pengxn/go-xn/src/cmd.buildTime=${BUILD_TIME}"
+VERSION     = $(shell git describe --tags `git rev-list --tags --max-count=1`)
+COMMIT_ID   = $(shell git rev-parse --short HEAD)
+BUILD_TIME  = $(shell date +'%Y-%m-%d %T')
+LDFLAGS    += -X "github.com/Pengxn/go-xn/src/cmd.Version=${VERSION}"
+LDFLAGS    += -X "github.com/Pengxn/go-xn/src/cmd.commitID=${COMMIT_ID}"
+LDFLAGS    += -X "github.com/Pengxn/go-xn/src/cmd.buildTime=${BUILD_TIME}"
 
 all: build
 
 build: clean
-	@go build -o build/$(BIN) -ldflags '-w -s $(LDFLAGS)'
+	@go build -o build/$(BIN) -v -ldflags '-w -s $(LDFLAGS)'
 
 clean:
 	@if [ -f "build/$(BIN)" ]; then \


### PR DESCRIPTION
- Format variable declaration in the `Makefile` file to improve readability.
- Add `-v` build flag[^1] to print the names of packages as they are compiled.

[^1]: [go doc: cmd/go#Compile packages and dependencies](https://pkg.go.dev/cmd/go@go1.21.5#hdr-Compile_packages_and_dependencies)