### PR TITLE
Remove log warning prompt when default config file doesn't exist

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -4,7 +4,6 @@ import (
 	"github.com/go-ini/ini"
 	"github.com/google/uuid"
 
-	"github.com/Pengxn/go-xn/src/util/file"
 	"github.com/Pengxn/go-xn/src/util/log"
 )
 
@@ -19,9 +18,6 @@ func init() {
 	configPath := getConfigPathByFlag()
 	if configPath == "" {
 		configPath = "fyj.ini"
-		if !file.IsExist(configPath) || !file.IsFile(configPath) {
-			log.Warnln("Default config file not exist, use default config")
-		}
 	}
 
 	if err := loadConfig(configPath); err != nil {


### PR DESCRIPTION
Remove the log warning prompt when the default config file `fyj.ini` doesn't exist.

The log warning prompt will be displayed when running commands or web services before,
such as `version` subcommand:

```shell
$ ./build/go-xn version

WARN[0000] Default config file not exist, use default config
FYJ 0.0.1
---------------------------------
- Go version: go1.21.6
- Revision:   xxxxxxxx
- OS/Arch:    darwin/amd64
- Built time: 2024-01-20 00:00:00
```