### PR TITLE
Upgrade go toolchain version to `1.22`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,8 +27,7 @@ require (
 	xorm.io/xorm v1.3.9
 )
 
-go 1.21
-toolchain go1.22.5
+go 1.22
 
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-//go:build go1.21
+//go:build go1.22
 
 // Copyright 2020 The Go-xn Authors. All rights reserved.
 // Use of this source code is governed by a Zlib license


### PR DESCRIPTION
- Upgrade the minimum go toolchain version to `1.22` in `go.mod` file.
- Upgrade build constraints tag go version to `1.22`.

Remove `toolchain go1.22.5` line, for the last update of webauthn package. [^1]
The minimum version of go required to compile packages in `github.com/go-webauthn/webauthn` module is set to 1.22. [^2]

[^1]: commit hash [3f9aca2](https://github.com/Pengxn/go-xn/commit/3f9aca210c7e7a743c05394a2a2184a5b8823a43#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R31)
[^2]: [go-webauthn/webauthn commit b0b8ef1](https://github.com/go-webauthn/webauthn/commit/b0b8ef1ccc20847b3429e017e2ee76a623e6f4c0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R3)