### PR TITLE
Bump actions/upload-artifact to `v4`

### DIFF
--- a/.github/workflows/test.linux.yml
+++ b/.github/workflows/test.linux.yml
@@ -27,7 +27,7 @@ jobs:
           make
 
       - name: Publish Build Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: linux-amd64
           path: build/

--- a/.github/workflows/test.windows.yml
+++ b/.github/workflows/test.windows.yml
@@ -31,7 +31,7 @@ jobs:
           iscc .\script\windows\go-xn.iss
 
       - name: Publish Build Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: windows-amd64
           path: build/dist/


### PR DESCRIPTION
Bumps [`actions/upload-artifact`](https://github.com/actions/upload-artifact) to `v4`.
And starting **November 30, 2024**, GitHub Actions will no longer be able to use `v3` of `actions/upload-artifact`.

refer to the following links:
- [GitHub Actions – Artifacts `v4` is now Generally Available](https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available/)
- [Deprecation notice: `v3` of the artifact actions](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions)
- [actions/upload-artifact `v4.0.0.0` release notes](https://github.com/actions/upload-artifact/releases/tag/v4.0.0)