### PR TITLE
Bump actions/setup-go to `v5`

### DIFF
--- a/.github/workflows/test.linux.yml
+++ b/.github/workflows/test.linux.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
           cache: false
 
       - name: Run tests

--- a/.github/workflows/test.linux.yml
+++ b/.github/workflows/test.linux.yml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: 1.21.x
           cache: false

--- a/.github/workflows/test.windows.yml
+++ b/.github/workflows/test.windows.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
           cache: false
 
       - name: Run tests

--- a/.github/workflows/test.windows.yml
+++ b/.github/workflows/test.windows.yml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: 1.21.x
           cache: false


### PR DESCRIPTION
Bumps [actions/setup-go](https://github.com/actions/setup-go) to `v5`.
The `actions/setup-go@v4` uses a deprecated node version and will be forced to run on node 20.

refer to the following links:
- [GitHub Actions; All Actions will run on Node20 instead of Node16 by default](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/)
- [GitHub Actions: Transitioning from Node 16 to Node 20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)
- [actions/setup-go `v5.0.0` release notes](https://github.com/actions/setup-go/releases/tag/v5.0.0)