### PR TITLE
Upgrade go toolchain version to `1.23`

### DIFF
--- a/.github/workflows/test.linux.yml
+++ b/.github/workflows/test.linux.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
           cache: false
 
       - name: Run tests

--- a/.github/workflows/test.windows.yml
+++ b/.github/workflows/test.windows.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
           cache: false
 
       - name: Run tests

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	xorm.io/xorm v1.3.9
 )
 
-go 1.22
+go 1.23
 
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-//go:build go1.22
+//go:build go1.23
 
 // Copyright 2020 The Go-xn Authors. All rights reserved.
 // Use of this source code is governed by a Zlib license


### PR DESCRIPTION
- Upgrade the minimum go toolchain version to `1.23` in `go.mod` file.
- Upgrade the minimum go version implied by the build constraints tag expression to `1.23`.
- Update go version to `1.23.x` for GitHub Actions.