### PR TITLE
Bump docker/build-push-action to `v6`

### DIFF
--- a/.github/workflows/test.docker.yml
+++ b/.github/workflows/test.docker.yml
@@ -41,7 +41,7 @@ jobs:
           echo "GCHR_USER=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
 
       - name: Build and Push Docker Image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
This major release adds support for generating [build summary](https://github.blog/news-insights/product-news/supercharging-github-actions-with-job-summaries/) and exporting build record for your build.

refer to [release `v6.0.0`](https://github.com/docker/build-push-action/releases/tag/v6.0.0)