### PR TITLE
Update `github.com/go-mail/mail` package and import path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/getsentry/sentry-go v0.30.0
 	github.com/gin-gonic/gin v1.10.0
 	github.com/go-ini/ini v1.67.0
-	github.com/go-mail/mail/v2 v2.3.0
+	github.com/go-mail/mail v2.3.1+incompatible
 	github.com/go-sql-driver/mysql v1.8.1
 	github.com/go-webauthn/webauthn v0.11.2
 	github.com/golang-jwt/jwt/v5 v5.2.1

--- a/src/lib/mail/mail.go
+++ b/src/lib/mail/mail.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"html/template"
 
-	"github.com/go-mail/mail/v2"
+	"github.com/go-mail/mail"
 
 	"github.com/Pengxn/go-xn/src/config"
 	"github.com/Pengxn/go-xn/src/util/log"


### PR DESCRIPTION
- Update package `github.com/go-mail/mail/v2 v2.3.0` to `github.com/go-mail/mail v2.3.1+incompatible` in go.mod.
- Update import path in mail.go to reflect package change.