### PR TITLE
Add bitcoin `BIP15` alias partial support

### DIFF
--- a/src/controller/bitcoin.go
+++ b/src/controller/bitcoin.go
@@ -1,0 +1,26 @@
+package controller
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"github.com/Pengxn/go-xn/src/model"
+)
+
+// BitcoinAliases returns the Bitcoin BIP15 alias for specified user.
+// Note: The status of standard BIP15 aliases is deferred.
+//
+// Any => /bitcoin-alias/?handle=fengyj
+func BitcoinAliases(c *gin.Context) {
+	// TODO: deal with query parameters for different handles.
+	has, alias, err := model.GetOptionByName("bitcoin-alias")
+	if err != nil {
+		errorJSON(c, 500, "failed to get bitcoin alias")
+		return
+	}
+	if !has || alias.Value == "" {
+		c.String(404, "the bitcoin alias don't exist")
+		return
+	}
+
+	c.String(200, alias.Value)
+}

--- a/src/route/others.go
+++ b/src/route/others.go
@@ -42,4 +42,8 @@ func othersRoutes(g *gin.Engine) {
 	// to https://blog.svend.cc/upic/tutorials/custom
 	g.POST("/upload/upic", controller.UploadFileForUPic)
 	g.Static("/upic", "data/uPic")
+
+	// Bitcoin BIP15 aliases, the status of standard BIP15 aliases is deferred, refer to:
+	// https://github.com/bitcoin/bips/blob/master/bip-0015.mediawiki#https-web-service
+	g.Any("/bitcoin-alias", controller.BitcoinAliases)
 }


### PR DESCRIPTION
- Add bitcoin alias endpoint `/bitcoin-alias` that returns BIP15 alias value.
- Implement `GET` (and other methods) handler to fetch bitcoin alias from database.

⚠️ note: This follows `BIP15` partial specification but its standardization status remains `deferred`.

refer to: https://github.com/bitcoin/bips/blob/master/bip-0015.mediawiki#https-web-service