### PR TITLE
Support IDN domain whois query

### DIFF
--- a/src/controller/others.go
+++ b/src/controller/others.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/feeds"
+	"golang.org/x/net/idna"
 
 	"github.com/Pengxn/go-xn/src/lib/markdown"
 	"github.com/Pengxn/go-xn/src/lib/whois"
@@ -24,6 +25,13 @@ func GwtWhoisInfo(c *gin.Context) {
 	domain = strings.TrimSuffix(domain, ".") // Trim the dot at the end
 	if len(strings.Split(domain, ".")) < 2 { // Need a TLD and a domain body
 		c.String(403, "Param (domain="+domain+") is invaild")
+		return
+	}
+	// Convert domain to punycode if it includes non-ASCII characters
+	domain, err := idna.ToASCII(domain)
+	if err != nil {
+		log.Errorf("convert punycode error: %+v, domain: %s", err, domain)
+		c.String(403, err.Error())
 		return
 	}
 

--- a/src/lib/whois/whois.go
+++ b/src/lib/whois/whois.go
@@ -16,7 +16,6 @@ import (
 // and https://publicsuffix.org/list/public_suffix_list.dat
 func GetWhois(domain string) (string, error) {
 	// TODO: Check the domain by regexp
-	// TODO: Convert special domain by punnycode
 	whoisServer, err := getWhoisServer(domain)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Add support for `Internationalized Domain Names (IDN)` by converting domains to `Punycode` before performing a whois lookup.
This converts the domain to punycode if it contains non-ASCII characters.