### PR TITLE
Add security.txt `RFC 9116` standard support

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+
+# Security Policy
+
+## Reporting a Vulnerability
+
+We welcome whoever finds a security vulnerability to report it to us.
+
+You can find our contact information in the [`security.txt`](/web/security.txt) file.

--- a/src/route/others.go
+++ b/src/route/others.go
@@ -1,10 +1,13 @@
 package route
 
 import (
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 
 	"github.com/Pengxn/go-xn/src/controller"
 	"github.com/Pengxn/go-xn/src/middleware"
+	"github.com/Pengxn/go-xn/web"
 )
 
 // othersRoutes registers other routes.
@@ -28,6 +31,11 @@ func othersRoutes(g *gin.Engine) {
 	// WebAuthn well-known URIs, note: its status is still proposal, refer to:
 	// https://github.com/w3c/webauthn/wiki/Explainer:-Related-origin-requests#proposal
 	wuris.Any("/webauthn", controller.WebAuthnWellKnown)
+
+	// Security.txt, refer to: https://securitytxt.org/
+	// and https://www.iana.org/assignments/security-txt-fields/security-txt-fields.xhtml
+	// and https://datatracker.ietf.org/doc/html/rfc9116
+	staticFileFromFS(g, "/.well-known/security.txt", "security.txt", http.FS(web.Other))
 
 	// WebDAV, server for WebDAV service.
 	webdav := g.Group("/dav").Use(middleware.BasicAuth())

--- a/web/embed.go
+++ b/web/embed.go
@@ -11,6 +11,7 @@ var (
 
 	//go:embed robots.txt
 	//go:embed humans.txt
+	//go:embed security.txt
 	//go:embed icons
 	Other embed.FS
 

--- a/web/security.txt
+++ b/web/security.txt
@@ -1,0 +1,17 @@
+Contact: mailto:i@xn--02f.com
+
+Preferred-Languages: en
+Canonical: https://xn--02f.com/.well-known/security.txt
+
+# Policy: https://example.com/disclosure-policy.html
+# Hiring: https://example.com/jobs.html
+
+# Acknowledgments: https://example.com/acknowledgments
+# Expires: 2025-12-31T18:37:07z
+
+# Example of an OpenPGP key available from a web server:
+# Encryption: https://example.com/key.gpg
+# Example of an OpenPGP key available from an OPENPGPKEY DNS record:
+# Encryption: dns:5d2d37ab76d47d36._openpgpkey.example.com?type=OPENPGPKEY
+# Example of an OpenPGP key being referenced by its fingerprint:
+# Encryption: openpgp4fpr:5f2de5521c63a801ab59ccb603d49de44b29100f

--- a/web/security.txt
+++ b/web/security.txt
@@ -1,3 +1,4 @@
+Contact: https://github.com/Pengxn/go-xn/blob/main/SECURITY.md
 Contact: mailto:i@xn--02f.com
 
 Preferred-Languages: en
@@ -7,7 +8,7 @@ Canonical: https://xn--02f.com/.well-known/security.txt
 # Hiring: https://example.com/jobs.html
 
 # Acknowledgments: https://example.com/acknowledgments
-# Expires: 2025-12-31T18:37:07z
+# Expires: 2025-12-31T23:59:00z
 
 # Example of an OpenPGP key available from a web server:
 # Encryption: https://example.com/key.gpg


### PR DESCRIPTION
- Implement RFC 9116 security.txt standard, refer to https://datatracker.ietf.org/doc/html/rfc9116
- Register `/.well-known/security.txt` route and serve it from the embedded filesystem.

The `security.txt` file provides contact website owner's information for security issues.