### PR TITLE
Implement cloudflare Turnstile server-side validation integration

### DIFF
--- a/src/lib/turnstile/turnstile.go
+++ b/src/lib/turnstile/turnstile.go
@@ -1,0 +1,42 @@
+package turnstile
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// New creates a new Turnstile struct with the secret set.
+func New(secret string) *Turnstile {
+	return &Turnstile{
+		Secret:       secret,
+		TurnstileURL: apiURL,
+	}
+}
+
+// Verify verifies a "cf-turnstile-response" data field, with an optional remote IP set.
+func (t *Turnstile) Verify(response, remoteip string) (*Response, error) {
+	values := url.Values{"secret": {t.Secret}, "response": {response}}
+	if remoteip != "" {
+		values.Set("remoteip", remoteip)
+	}
+	resp, err := http.PostForm(t.TurnstileURL, values)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP error: %w", err)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP read error: %w", err)
+	}
+
+	r := Response{}
+	err = json.Unmarshal(body, &r)
+	if err != nil {
+		return nil, fmt.Errorf("JSON error: %w", err)
+	}
+
+	return &r, nil
+}

--- a/src/lib/turnstile/type.go
+++ b/src/lib/turnstile/type.go
@@ -1,0 +1,56 @@
+package turnstile
+
+var apiURL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+
+// Turnstile is a struct that holds the secret and the Turnstile API URL.
+type Turnstile struct {
+	Secret       string
+	TurnstileURL string
+}
+
+// Response is the response from the Turnstile API, refer to
+// https://developers.cloudflare.com/turnstile/get-started/server-side-validation/
+type Response struct {
+	// Success indicates if the challenge was passed.
+	Success bool `json:"success"`
+	// ErrorCodes is a list of errors that occurred. (failure only)
+	ErrorCodes []string `json:"error-codes"`
+	// ChallengeTs is the ISO timestamp for the time the challenge was solved.
+	ChallengeTs string `json:"challenge_ts"`
+	// Hostname is the hostname for which the challenge was served.
+	Hostname string `json:"hostname"`
+	// action is the customer widget identifier passed to the widget on the client side.
+	// This is used to differentiate widgets using the same sitekey in analytics.
+	// Its integrity is protected by modifications from an attacker. It is recommended to
+	// validate that the action matches an expected value.
+	Action string `json:"action"`
+	// CData is the customer data passed to the widget on the client side.
+	// This can be used by the customer to convey state. It is integrity protected by
+	// modifications from an attacker.
+	CData string `json:"cdata"`
+	// EphemeralID returns the Ephemeral ID in siteverify. (enterprise only)
+	EphemeralID string `json:"ephemeral_id"`
+}
+
+var (
+	// The secret parameter was not passed.
+	ErrMissingInputSecret = "missing-input-secret"
+	// The secret parameter was invalid, did not exist,
+	// or is a testing secret key with a non-testing response.
+	ErrInvalidInputSecret = "invalid-input-secret"
+	// The response parameter (token) was not passed.
+	ErrMissingInputResponse = "missing-input-response"
+	// The response parameter (token) is invalid or has expired.
+	// Most of the time, this means a fake token has been used.
+	// If the error persists, contact customer support.
+	ErrInvalidInputResponse = "invalid-input-response"
+	// The request was rejected because it was malformed.
+	ErrBadRequest = "bad-request"
+	// The response parameter (token) has already been validated before.
+	// This means that the token was issued five minutes ago and is no longer valid,
+	// or it was already redeemed.
+	ErrTimeoutOrDuplicate = "timeout-or-duplicate"
+	// An internal error happened while validating the response.
+	// The request can be retried.
+	ErrInternalError = "internal-error"
+)


### PR DESCRIPTION
- Define the `Turnstile` struct to hold the secret and API URL.
- Add type definitions for Turnstile API response and error codes.
- Implement Turnstile client structure and verification logic.

refer to https://developers.cloudflare.com/turnstile/get-started/server-side-validation/