### PR TITLE
Move `SECURITY.md` to `.github` directory

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -5,4 +5,4 @@
 
 We welcome whoever finds a security vulnerability to report it to us.
 
-You can find our contact information in the [`security.txt`](/web/security.txt) file.
+You can find our contact information in the [`security.txt`](../web/security.txt) file.

--- a/web/security.txt
+++ b/web/security.txt
@@ -1,4 +1,4 @@
-Contact: https://github.com/Pengxn/go-xn/blob/main/SECURITY.md
+Contact: https://github.com/Pengxn/go-xn/blob/main/.github/SECURITY.md
 Contact: mailto:i@xn--02f.com
 
 Preferred-Languages: en


### PR DESCRIPTION
- Update relative links and paths in `SECURITY.md` and `security.txt` files to point to right location.
- Move `SECURITY.md` from root directory to `.github` directory for better organization.

refer to https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository#about-security-policies