### PR TITLE
Release `0.0.2` version

### DIFF
--- a/script/windows/go-xn.iss
+++ b/script/windows/go-xn.iss
@@ -6,7 +6,7 @@
 ;     [guid]::NewGuid().ToString()
 #define APP_ID '9F00A778-1C16-4F7D-8FE4-0CDE4FC712DD'
 #define APP_NAME 'Go-xn'
-#define VERSION '0.0.1'
+#define VERSION '0.0.2'
 #define PUBLISHER 'xn-02f Lab'
 #define URL 'https://xn--02f.com'
 #define EXE_NAME 'go-xn.exe'

--- a/web/assets/js/main.js
+++ b/web/assets/js/main.js
@@ -1,4 +1,4 @@
-const APP_VERSION = '0.0.1'
+const APP_VERSION = '0.0.2'
 let YEAR = new Date().getFullYear()
 
 /**

--- a/web/humans.txt
+++ b/web/humans.txt
@@ -13,7 +13,7 @@
 	GitHub Contributors: Peng.xn (@Pengxn) and others。
 
 /* SITE */
-	Version: 0.0.1
-	Last Update: 2012/02/04
+	Version: 0.0.2
+	Last Update: 2025/01/20
 	Language: Chinese / English
 	Source Code: https://github.com/Pengxn/go-xn


### PR DESCRIPTION
Release `0.0.2` version, refer to [milestone 0.0.2](https://github.com/Pengxn/go-xn/milestone/3).

