### PR TITLE
Improve API routes with `JWT` middleware

### DIFF
--- a/src/api/admin.go
+++ b/src/api/admin.go
@@ -1,11 +1,34 @@
 package api
 
-import "github.com/gin-gonic/gin"
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/Pengxn/go-xn/src/lib/jwt"
+)
 
 type adminAPI struct{}
 
 func NewAdminAPI() *adminAPI {
 	return &adminAPI{}
+}
+
+func (a *adminAPI) Token(c *gin.Context) {
+	claims := jwt.NewClaims(1, "admin")
+	token, err := jwt.TokenFromClaims(claims)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"code":    http.StatusInternalServerError,
+			"message": "token generation failed",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"code":  http.StatusOK,
+		"token": token,
+	})
 }
 
 func (a *adminAPI) RegisterAdmin(c *gin.Context) {

--- a/src/config/example.ini
+++ b/src/config/example.ini
@@ -7,8 +7,8 @@ port     = 7991          # server port       (default: 7991)
 tls      = false         # enable tls        (default: false)
 certFile = cert_file.crt # tls cert file path
 keyFile  = key_file.key  # tls key file path
-jwtToken = secret        # jwt token secret     (default: random uuid string)
-jwtExp   = 0             # jwt token expire hour (default: 0, 0 means never expire)
+jwtToken = secret        # jwt token secret      (default: random uuid string)
+jwtExp   = 0             # jwt token expire time (default: 0, never expire, unit: day)
 
 [database]
 type     = SQLite3   # MySQL, PostgreSQL, SQLite3   (default: SQLite3)

--- a/src/lib/jwt/jwt.go
+++ b/src/lib/jwt/jwt.go
@@ -1,0 +1,37 @@
+package jwt
+
+import (
+	"time"
+
+	"github.com/Pengxn/go-xn/src/config"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+type Claims struct {
+	UID      int    `json:"uid"`
+	Username string `json:"username"`
+	jwt.RegisteredClaims
+}
+
+func NewClaims(uid int, username string) Claims {
+	now := time.Now()
+
+	claims := Claims{
+		UID:      uid,
+		Username: username,
+		RegisteredClaims: jwt.RegisteredClaims{
+			IssuedAt: jwt.NewNumericDate(now),
+		},
+	}
+	// Set expiration time if config value is set, the value is in days.
+	if config.Config.Server.JwtExp > 0 {
+		claims.ExpiresAt = jwt.NewNumericDate(now.AddDate(0, 0, config.Config.Server.JwtExp))
+	}
+
+	return claims
+}
+
+func TokenFromClaims(claims Claims) (string, error) {
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString([]byte(config.Config.Server.JwtToken))
+}

--- a/src/lib/jwt/jwt.go
+++ b/src/lib/jwt/jwt.go
@@ -3,8 +3,9 @@ package jwt
 import (
 	"time"
 
-	"github.com/Pengxn/go-xn/src/config"
 	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/Pengxn/go-xn/src/config"
 )
 
 type Claims struct {

--- a/src/middleware/jwt.go
+++ b/src/middleware/jwt.go
@@ -12,6 +12,7 @@ import (
 
 func JWT() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// Parse JWT token from request `Authorization` header
 		token, err := request.ParseFromRequest(c.Request, request.AuthorizationHeaderExtractor,
 			func(token *jwt.Token) (any, error) {
 				return []byte(config.Config.Server.JwtToken), nil
@@ -34,6 +35,7 @@ func JWT() gin.HandlerFunc {
 		}
 
 		c.Set("username", claims["username"])
+		c.Set("uid", claims["uid"])
 		c.Next()
 	}
 }

--- a/src/route/api.go
+++ b/src/route/api.go
@@ -1,13 +1,18 @@
 package route
 
 import (
-	"github.com/Pengxn/go-xn/src/api"
 	"github.com/gin-gonic/gin"
+
+	"github.com/Pengxn/go-xn/src/api"
+	"github.com/Pengxn/go-xn/src/middleware"
 )
 
 func apiRoutes(g *gin.Engine) {
 	adminAPI := api.NewAdminAPI()
 
-	api := g.Group("/api")
+	// API without JWT authentication
+	g.GET("/api/token", adminAPI.Token)
+
+	api := g.Group("/api").Use(middleware.JWT())
 	api.POST("/admin", adminAPI.RegisterAdmin)
 }


### PR DESCRIPTION
- Use `JWT` middleware for the `/api` route group to authenticate requests.
- Implement JWT token generation function by wrapping the `github.com/golang-jwt/jwt/v5` package.