### PR TITLE
Serve `keybase.txt` file to proof keybase ownership

### DIFF
--- a/src/route/static.go
+++ b/src/route/static.go
@@ -33,6 +33,8 @@ func staticRoutes(g *gin.Engine) {
 	// and https://www.iana.org/assignments/security-txt-fields/security-txt-fields.xhtml
 	// and https://datatracker.ietf.org/doc/html/rfc9116
 	staticFile(g, "/.well-known/security.txt", "security.txt", localFS, otherFS)
+	// keybase.txt, refer to: https://keybase.io/docs/keybase_well_known
+	staticFile(g, "/.well-known/keybase.txt", "keybase.txt", localFS, otherFS)
 }
 
 func staticFile(g *gin.Engine, relativePath, filepath string, localfs, embedfs http.FileSystem) {


### PR DESCRIPTION
- Add `/.well-known/keybase.txt` route to serve `keybase.txt` file from multiple filesystems.
- Follow Keybase proof system specification to serve `keybase.txt` file, refer to [The "keybase" Well-Known Resource Identifier](https://keybase.io/docs/keybase_well_known).