### PR TITLE
Add `OAuth2` authentication route structure

### DIFF
--- a/src/route/auth.go
+++ b/src/route/auth.go
@@ -1,0 +1,16 @@
+package route
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+func authRoutes(g *gin.Engine) {
+	// OAuth2
+	g.POST("/oauth/:provider", oauth2)
+	g.POST("/oauth/callback", oauth2)
+	g.POST("/oauth/logout", oauth2)
+}
+
+func oauth2(c *gin.Context) {
+	c.String(200, "not implemented")
+}

--- a/src/route/route.go
+++ b/src/route/route.go
@@ -26,6 +26,7 @@ func InitRoutes() error {
 		debugRoutes(g)
 	}
 	apiRoutes(g)
+	authRoutes(g)
 	errorRoute(g)
 	adminRoutes(g)
 	othersRoutes(g)


### PR DESCRIPTION
- Create basic OAuth2 routes for provider auth, callback, and logout.
- Add placeholder implementation for OAuth2 handler.
- Register `authRoutes` in main route initialization.