### PR TITLE
Add bcrypt password hashing utility functions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	github.com/urfave/cli/v2 v2.27.5
 	github.com/yuin/goldmark v1.7.8
+	golang.org/x/crypto v0.32.0
 	golang.org/x/net v0.34.0
 	google.golang.org/grpc v1.69.4
 	google.golang.org/protobuf v1.36.3
@@ -75,7 +76,6 @@ require (
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
 	golang.org/x/arch v0.8.0 // indirect
-	golang.org/x/crypto v0.32.0 // indirect
 	golang.org/x/sys v0.29.0 // indirect
 	golang.org/x/term v0.28.0 // indirect
 	golang.org/x/text v0.21.0 // indirect

--- a/src/lib/bcrypt/password.go
+++ b/src/lib/bcrypt/password.go
@@ -1,0 +1,15 @@
+package bcrypt
+
+import "golang.org/x/crypto/bcrypt"
+
+func Generate(password string) (string, error) {
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		return "", err
+	}
+	return string(hash), nil
+}
+
+func Vaildate(password, hash string) error {
+	return bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
+}


### PR DESCRIPTION
- Update `golang.org/x/crypto` dependency from indirect to direct.
- Add `Generate` function to generate password hash using bcrypt algorithm.
- Add `Vaildate` function to vaildate password against stored hash.
- Set default bcrypt cost parameter to `10`, refer to [bcrypt/bcrypt.go#DefaultCost](https://github.com/golang/crypto/blob/v0.32.0/bcrypt/bcrypt.go#L24).