### PR TITLE
Use std `log` library to log startup errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,12 +7,13 @@
 package main
 
 import (
+	"log"
+
 	"github.com/Pengxn/go-xn/src/cmd"
-	"github.com/Pengxn/go-xn/src/util/log"
 )
 
 func main() {
 	if err := cmd.Execute(); err != nil {
-		log.Fatalln("Fail to start app...", err)
+		log.Fatalln("fail to start app:", err)
 	}
 }


### PR DESCRIPTION
Switch from custom logger to std `log` library for starup errors.