### PR TITLE
Add health check endpoint

### DIFF
--- a/src/route/route.go
+++ b/src/route/route.go
@@ -22,6 +22,9 @@ func InitRoutes() error {
 	// Page number handler
 	g.GET("/page/:pageNum", controller.ArticlesPage)
 
+	// Health check
+	g.GET("/health", func(c *gin.Context) { c.String(200, "ok") })
+
 	if serverConfig.Debug {
 		debugRoutes(g)
 	}


### PR DESCRIPTION
- Add `GET => /health` endpoint for basic service health check.
- Return "ok" with `200` status code directly for health check requests.

> Note: the check logic don't implement any monitoring, tracing, or others.