### PR TITLE
Use `cobra` library to refactor command line

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,8 +20,8 @@ require (
 	github.com/schollz/progressbar/v3 v3.13.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/smartystreets/goconvey v1.8.1
+	github.com/spf13/cobra v1.7.0
 	github.com/tidwall/gjson v1.17.0
-	github.com/urfave/cli/v2 v2.25.7
 	github.com/yuin/goldmark v1.6.0
 	golang.org/x/net v0.17.0
 	xorm.io/xorm v1.3.4
@@ -34,7 +34,6 @@ require (
 	github.com/bytedance/sonic v1.9.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
-	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/fxamacker/cbor/v2 v2.4.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
@@ -47,6 +46,7 @@ require (
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/go-tpm v0.9.0 // indirect
 	github.com/gopherjs/gopherjs v1.17.2 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/klauspost/cpuid/v2 v2.2.4 // indirect
@@ -59,15 +59,14 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
-	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/smarty/assertions v1.15.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/syndtr/goleveldb v1.0.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
-	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	golang.org/x/arch v0.3.0 // indirect
 	golang.org/x/crypto v0.14.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect

--- a/main.go
+++ b/main.go
@@ -8,11 +8,8 @@ package main
 
 import (
 	"github.com/Pengxn/go-xn/src/cmd"
-	"github.com/Pengxn/go-xn/src/util/log"
 )
 
 func main() {
-	if err := cmd.Execute(); err != nil {
-		log.Fatalln("Fail to start app...", err)
-	}
+	cmd.Execute()
 }

--- a/src/cmd/cmd.go
+++ b/src/cmd/cmd.go
@@ -1,23 +1,19 @@
 package cmd
 
 import (
-	"os"
+	"github.com/spf13/cobra"
 
-	"github.com/urfave/cli/v2"
+	"github.com/Pengxn/go-xn/src/util/log"
 )
 
-// Execute to run cmd
-func Execute() error {
-	app := &cli.App{
-		Name:    "go-xn",
-		Usage:   "The platform for publishing and running your blog",
-		Version: Version,
-		Commands: []*cli.Command{
-			Web,
-			Update,
-			VersionCmd,
-		},
-	}
+var app = &cobra.Command{
+	Use:   "go-xn",
+	Short: "The platform for publishing and running your blog",
+}
 
-	return app.Run(os.Args)
+// Execute to run cmd
+func Execute() {
+	if err := app.Execute(); err != nil {
+		log.Fatalln("Fail to start app...", err)
+	}
 }

--- a/src/cmd/update.go
+++ b/src/cmd/update.go
@@ -8,24 +8,33 @@ import (
 	"path/filepath"
 
 	"github.com/schollz/progressbar/v3"
-	"github.com/urfave/cli/v2"
+	"github.com/spf13/cobra"
 
 	"github.com/Pengxn/go-xn/src/util/httplib"
+	"github.com/Pengxn/go-xn/src/util/log"
 )
+
+func init() {
+	app.AddCommand(Update)
+}
 
 var (
 	nightlyURL = "https://nightly.link/Pengxn/go-xn/workflows/test/main/linux-amd64.zip"
 
 	// Update is "update" subcommand.
 	// It's used to update command binary to the latest version.
-	Update = &cli.Command{
-		Name:   "update",
-		Usage:  "Update the binary to the latest version",
-		Action: update,
+	Update = &cobra.Command{
+		Use:   "update",
+		Short: "Update the binary to the latest version",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := update(cmd, args); err != nil {
+				log.Error("Fail to update binary.", err)
+			}
+		},
 	}
 )
 
-func update(c *cli.Context) error {
+func update(cmd *cobra.Command, args []string) error {
 	resp, err := httplib.New().GET(nightlyURL)
 	if err != nil {
 		return err

--- a/src/cmd/version.go
+++ b/src/cmd/version.go
@@ -4,8 +4,15 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/urfave/cli/v2"
+	"github.com/spf13/cobra"
 )
+
+func init() {
+	app.Version = showVersion()
+	app.SetVersionTemplate(`{{ printf "%s" .Version }}`)
+
+	app.AddCommand(VersionCmd)
+}
 
 // Version information for cmd
 // Use "var" (not const) to defined variable for `go build -ldflags`
@@ -18,18 +25,20 @@ var (
 
 	// VersionCmd is "version" subcommand.
 	// It prints the version, revision and built time information to stdout.
-	VersionCmd = &cli.Command{
-		Name:  "version",
-		Usage: "Print some information about version",
-		Description: `Prints version information that might help you get out of trouble.
+	VersionCmd = &cobra.Command{
+		Use:   "version",
+		Short: "Print some information about version",
+		Long: `Prints version information that might help you get out of trouble.
 And it display revision and built time information.`,
-		Action: showVersion,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Print(showVersion())
+		},
 	}
 )
 
 // showVersion prints the version information to stdout
-func showVersion(c *cli.Context) error {
-	fmt.Printf(`FYJ %s
+func showVersion() string {
+	return fmt.Sprintf(`FYJ %s
 ---------------------------------
 - Go version: %s
 - Revision:   %s
@@ -37,6 +46,4 @@ func showVersion(c *cli.Context) error {
 - Built time: %s
 `, Version, runtime.Version(), commitID,
 		runtime.GOOS, runtime.GOARCH, buildTime)
-
-	return nil
 }

--- a/src/config/cmd.go
+++ b/src/config/cmd.go
@@ -3,15 +3,13 @@ package config
 import (
 	"os"
 
-	"github.com/urfave/cli/v2"
-
 	"github.com/Pengxn/go-xn/src/util/file"
 	"github.com/Pengxn/go-xn/src/util/log"
 )
 
-func OverrideConfigByFlag(c *cli.Context) {
-	if c.IsSet("config") { // specified config file
-		f := c.Path("config")
+func OverrideConfigByFlag(config, port string, debug bool) {
+	if config != "" { // specified config file
+		f := config
 		if !file.IsExist(f) || !file.IsFile(f) {
 			log.Error("Specified config file not found: " + f)
 		}
@@ -20,12 +18,10 @@ func OverrideConfigByFlag(c *cli.Context) {
 		}
 	}
 	// Server config
-	if c.IsSet("port") {
-		Config.Server.Port = c.String("port")
+	if port != "" {
+		Config.Server.Port = port
 	}
-	if c.IsSet("debug") {
-		Config.Server.Debug = c.Bool("debug")
-	}
+	Config.Server.Debug = debug
 }
 
 func getConfigPathByFlag() string {


### PR DESCRIPTION
- Refactor cmd package by using `cobra` library instead of previous `cli` library, migrate from `urfave/cli/v2` to `spf13/cobra`.
- Update `OverrideConfigByFlag` function to override config by parsing flag parameters beforehand.
- Update go dependencies:
  * Remove previous [cli](https://github.com/urfave/cli) dependency.
  * Add [cobra](https://github.com/spf13/cobra) dependency.