### PR TITLE
Rename and standardize command variable names

### DIFF
--- a/src/cmd/agent.go
+++ b/src/cmd/agent.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	agent = &cli.Command{
+	agentCmd = &cli.Command{
 		Name:  "agent",
 		Usage: "Run as an agent",
 		Description: `Run as an agent, which can be used to manage the server.

--- a/src/cmd/cmd.go
+++ b/src/cmd/cmd.go
@@ -13,10 +13,10 @@ func Execute() error {
 		Usage:   "The platform for publishing and running your blog",
 		Version: Version,
 		Commands: []*cli.Command{
-			Web,
-			Update,
-			VersionCmd,
-			agent,
+			webCmd,
+			updateCmd,
+			versionCmd,
+			agentCmd,
 		},
 	}
 

--- a/src/cmd/update.go
+++ b/src/cmd/update.go
@@ -18,7 +18,7 @@ var (
 
 	// Update is "update" subcommand.
 	// It's used to update command binary to the latest version.
-	Update = &cli.Command{
+	updateCmd = &cli.Command{
 		Name:   "update",
 		Usage:  "Update the binary to the latest version",
 		Action: update,

--- a/src/cmd/version.go
+++ b/src/cmd/version.go
@@ -18,7 +18,7 @@ var (
 
 	// VersionCmd is "version" subcommand.
 	// It prints the version, revision and built time information to stdout.
-	VersionCmd = &cli.Command{
+	versionCmd = &cli.Command{
 		Name:  "version",
 		Usage: "Print some information about version",
 		Description: `Prints version information that might help you get out of trouble.

--- a/src/cmd/web.go
+++ b/src/cmd/web.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	// Web is "web" subcommand. It's used to run web server.
-	Web = &cli.Command{
+	webCmd = &cli.Command{
 		Name:  "web",
 		Usage: "Start web server interface for blog",
 		Description: `Run a performant web server which serves the site for blog.


### PR DESCRIPTION
- Rename command variables to follow consistent naming pattern with `Cmd` suffix.
- Update the following command variable names:
  * Web -> webCmd
  * Update -> updateCmd
  * VersionCmd -> versionCmd
  * agent -> agentCmd

This change improves code consistency and readability by using a uniform naming convention for all command variables.