### PR TITLE
ci: update trigger event configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,6 @@
 name: test
 
-on:
-  push:
-    paths-ignore:
-      - 'test/azure-pipelines/**'
-  pull_request:
-    paths-ignore:
-      - 'test/azure-pipelines/**'
+on: [push, pull_request]
 
 jobs:
   test-linux:


### PR DESCRIPTION
Remove the `test/azure-pipelines/*` path exclusion, and allow the workflow to run on all pushes and pull requests.
Simplify the GitHub Actions workflow trigger configuration by removing complex `paths-ignore` setup.