### PR TITLE
Add `NoIndex` middleware for preventing search engine indexing

### DIFF
--- a/src/middleware/robots_noindex.go
+++ b/src/middleware/robots_noindex.go
@@ -1,0 +1,12 @@
+package middleware
+
+import "github.com/gin-gonic/gin"
+
+func NoIndex() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Set the X-Robots-Tag header to noindex,
+		// refer to https://developers.google.com/search/reference/robots_meta_tag
+		c.Header("X-Robots-Tag", "noindex")
+		c.Next()
+	}
+}


### PR DESCRIPTION
Add a new middleware that sets `X-Robots-Tag` header to `noindex`, which can prevent search engine indexing for specific routes.

refer to [Robots meta tag, data-nosnippet, and X-Robots-Tag specifications](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#xrobotstag).