### PR TITLE
Remove `url` that was flagged as deprecated and replace it with `slug`

### DIFF
--- a/src/controller/article.go
+++ b/src/controller/article.go
@@ -71,7 +71,7 @@ func ListArticles(c *gin.Context) {
 //
 //	GET => /article/article-custom-url-path
 func GetArticle(c *gin.Context) {
-	article, exist := model.ArticleByURL(c.Param("url"))
+	article, exist := model.ArticleBySlug(c.Param("url"))
 	if !exist {
 		errorHTML(c, 404, "Article Not Found")
 		return

--- a/src/controller/article.go
+++ b/src/controller/article.go
@@ -66,12 +66,12 @@ func ListArticles(c *gin.Context) {
 	})
 }
 
-// GetArticle gets an article by 'url' param.
+// GetArticle gets an article by 'slug' param.
 // Request sample:
 //
-//	GET => /article/article-custom-url-path
+//	GET => /article/article-custom-slug-path
 func GetArticle(c *gin.Context) {
-	article, exist := model.ArticleBySlug(c.Param("url"))
+	article, exist := model.ArticleBySlug(c.Param("slug"))
 	if !exist {
 		errorHTML(c, 404, "Article Not Found")
 		return
@@ -118,7 +118,7 @@ func InsertArticle(c *gin.Context) {
 func UpdateArticle(c *gin.Context) {
 	c.JSON(200, gin.H{
 		"code": "Update an Article",
-		"data": c.Param("url"),
+		"data": c.Param("slug"),
 	})
 }
 
@@ -126,6 +126,6 @@ func UpdateArticle(c *gin.Context) {
 func DeleteArticle(c *gin.Context) {
 	c.JSON(200, gin.H{
 		"code": "Delete an Article",
-		"data": c.Param("url"),
+		"data": c.Param("slug"),
 	})
 }

--- a/src/model/article.go
+++ b/src/model/article.go
@@ -10,7 +10,6 @@ import (
 type Article struct {
 	ID         uint64     `json:"ID" xorm:"bigint(20) notnull autoincr pk 'ID'"`
 	Slug       string     `json:"slug,omitempty" xorm:"varchar(255) unique notnull 'slug'"`
-	URL        string     `json:"url,omitempty" xorm:"varchar(255) unique notnull 'url'"` // deprecated, use slug instead
 	Title      string     `json:"title" xorm:"text notnull 'title'"`
 	Content    string     `json:"content" xorm:"longtext notnull 'content'"`
 	Views      uint64     `json:"article_views" xorm:"bigint(20) notnull default(0) 'article_views'"`
@@ -27,7 +26,7 @@ func ArticlesByPage(limit int, page int) []Article {
 
 	var articles []Article
 	err := db.Table("article").
-		Cols("ID", "slug", "url", "title", "content", "article_views", "create_time").
+		Cols("ID", "slug", "title", "content", "article_views", "create_time").
 		Where("article_status = 1").
 		Limit(limit, limit*(page-1)).
 		Desc("create_time").
@@ -99,18 +98,18 @@ func ArticleByID(id uint64) (*Article, bool) {
 	return article, has
 }
 
-// ArticleByURL returns article by URL.
-func ArticleByURL(url string) (*Article, bool) {
+// ArticleBySlug returns article by slug.
+func ArticleBySlug(slug string) (*Article, bool) {
 	db := orm.NewSession()
 	defer db.Close()
 
 	article := &Article{
-		Slug: url,
+		Slug: slug,
 	}
 
 	has, err := db.Get(article)
 	if err != nil {
-		log.Errorf("ArticleByURL throw error: %s", err)
+		log.Errorf("ArticleBySlug throw error: %s", err)
 	}
 
 	return article, has

--- a/src/route/article.go
+++ b/src/route/article.go
@@ -11,8 +11,8 @@ func articlesRoutes(g *gin.Engine) {
 	g.Any("/articles", controller.ListArticles)
 
 	article := g.Group("/article")
-	article.GET("/:url", controller.GetArticle)
+	article.GET("/:slug", controller.GetArticle)
 	article.POST("/", controller.InsertArticle)
-	article.PUT("/:url", controller.UpdateArticle)
-	article.DELETE("/:url", controller.DeleteArticle)
+	article.PUT("/:slug", controller.UpdateArticle)
+	article.DELETE("/:slug", controller.DeleteArticle)
 }

--- a/test/sql/article.sql
+++ b/test/sql/article.sql
@@ -10,7 +10,6 @@
 DROP TABLE IF EXISTS `article`;
 CREATE TABLE `article` (
     `ID` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
-    `url` varchar(255) NOT NULL COMMENT 'The url of article', -- deprecated
     `slug` varchar(255) NOT NULL COMMENT 'The url of article',
     `title` text NOT NULL COMMENT 'The title of article',
     `content` longtext NOT NULL COMMENT 'The content of article',
@@ -30,7 +29,6 @@ CREATE TABLE `article` (
 INSERT INTO `article` VALUES (
     '1',
     "we-have-to-put-a-barrier-between-us-and-the-world",
-    "we-have-to-put-a-barrier-between-us-and-the-world",
     'Everybody listen! We have to put a barrier between us and the world!',
     'At Aspire Themes I use a lot of tools to help me create WordPress, Ghost and Jekyll themes. Tools will range from development, design, servi',
     '0',
@@ -41,7 +39,6 @@ INSERT INTO `article` VALUES (
 );
 INSERT INTO `article` VALUES (
     '2',
-    'if-you-have-an-opportunity-to-use-your-voice-you-should-use-it',
     'if-you-have-an-opportunity-to-use-your-voice-you-should-use-it',
     'If you have an opportunity to use your voice you should use it',
     'This service is just awesome, I use the Ghost Stack to install Ghost locally. This saves a lot of time and headache installing Ghost, and by',
@@ -54,7 +51,6 @@ INSERT INTO `article` VALUES (
 INSERT INTO `article` VALUES (
     '3',
     'writing-posts-with-Ghost',
-    'writing-posts-with-Ghost',
     'Writing posts with Ghost ✍️',
     'Getting started with the editor is simple, with familiar formatting options in a functional toolbar and the ability to add dynamic content seamlessly.',
     '0',
@@ -65,7 +61,6 @@ INSERT INTO `article` VALUES (
 );
 INSERT INTO `article` VALUES (
     '4',
-    'gathered-here-on-our-god-given-much-naeeded-day',
     'gathered-here-on-our-god-given-much-naeeded-day',
     'The reason we are gathered here on our God-given, much-naeeded day.',
     'iTerm is a replacement to Mac terminal, and I think most of you are using it for Mac. Tmux is a terminal multilpexer and a pretty great tool',
@@ -78,7 +73,6 @@ INSERT INTO `article` VALUES (
 INSERT INTO `article` VALUES (
     '5',
     'two-antarctic-penguins-took-an-adorable-selfie',
-    'two-antarctic-penguins-took-an-adorable-selfie',
     'Two antarctic penguins took an adorable selfie',
     'Welcome, it is great to have you here. We know that first impressions are important, so we have populated your new site with some initial getting started posts that will help you get familiar with everything in no time.',
     '0',
@@ -89,7 +83,6 @@ INSERT INTO `article` VALUES (
 );
 INSERT INTO `article` VALUES (
     '6',
-    'slow-cooker-honey-dijon-glazed-carrots',
     'slow-cooker-honey-dijon-glazed-carrots',
     'Slow cooker honey-dijon glazed carrots',
     'Getting started with the editor is simple, with familiar formatting options in a functional toolbar and the ability to add dynamic content seamlessly.',
@@ -102,7 +95,6 @@ INSERT INTO `article` VALUES (
 INSERT INTO `article` VALUES (
     '7',
     'managing-admin-settings',
-    'managing-admin-settings',
     'Managing admin settings',
     'There are a couple of things to do next while you are getting set up: making your site private and inviting your team.',
     '0',
@@ -113,7 +105,6 @@ INSERT INTO `article` VALUES (
 );
 INSERT INTO `article` VALUES (
     '8',
-    'nibh-labore-ac-condimentum-sequi-ullam',
     'nibh-labore-ac-condimentum-sequi-ullam',
     'Nibh labore ac condimentum sequi ullam',
     'Porro! Mollitia earum congue aliquid? Doloribus. Sociosqu hymenaeos! Ultrices, placerat accusantium iaculis? Irure voluptatibus accumsan odio? Aut, id hymenaeos officia reiciendis dictumst necessitatibus netus, voluptates doloribus porro sodales, eleifend! Mollis.',
@@ -126,7 +117,6 @@ INSERT INTO `article` VALUES (
 INSERT INTO `article` VALUES (
     '9',
     'dicta-montes-ac-doloremque-xercitation',
-    'dicta-montes-ac-doloremque-xercitation',
     'Dicta montes ac doloremque? Exercitation',
     'Welcome, it is great to have you here.We know that first impressions are important, so we have populated your new site with some initial getting started posts that will help you',
     '0',
@@ -138,7 +128,6 @@ INSERT INTO `article` VALUES (
 INSERT INTO `article` VALUES (
     '10',
     'vivamus-aliqua-ridiculus',
-    'vivamus-aliqua-ridiculus',
     'Molestie nostra consequatur. Vivamus aliqua ridiculus',
     'The Ghost editor has everything you need to fully optimise your content. This is where you can add tags and authors, feature a post, or turn a post into a',
     '0',
@@ -149,7 +138,6 @@ INSERT INTO `article` VALUES (
 );
 INSERT INTO `article` VALUES (
     '11',
-    'chinese-words-test',
     'chinese-words-test',
     '中文文本测试',
     '测试中文显示效果，仅用于展示文本显示及字体等效果。',

--- a/test/sql/article.sql
+++ b/test/sql/article.sql
@@ -10,7 +10,7 @@
 DROP TABLE IF EXISTS `article`;
 CREATE TABLE `article` (
     `ID` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
-    `slug` varchar(255) NOT NULL COMMENT 'The url of article',
+    `slug` varchar(255) NOT NULL COMMENT 'The slug of article',
     `title` text NOT NULL COMMENT 'The title of article',
     `content` longtext NOT NULL COMMENT 'The content of article',
     `article_views` bigint(20) NOT NULL DEFAULT 0 COMMENT 'Number of articles viewed',
@@ -19,7 +19,6 @@ CREATE TABLE `article` (
     `update_time` datetime NOT NULL COMMENT 'The time that article is updated',
     `delete_time` datetime NOT NULL COMMENT 'The time that article is deleted',
     PRIMARY KEY (`ID`),
-    UNIQUE KEY `url` (`url`),
     UNIQUE KEY `slug` (`slug`),
     KEY `create_time` (`create_time`)
 ) ENGINE=InnoDB AUTO_INCREMENT=69 DEFAULT CHARSET=utf8;

--- a/test/sql/user.sql
+++ b/test/sql/user.sql
@@ -31,7 +31,7 @@ INSERT INTO `user` VALUES (
     'Feng.YJ',
     'qw123456',
     '1',
-    'i@huiyifyj.cn',
+    'i@xn--02f.com',
     '1',
     '2017-04-07 10:17:50',
     '2019-04-12 16:17:10',


### PR DESCRIPTION
- Rename param from `:url` to `:slug` for article-related routes.
- Remove deprecated `url` field from Article model and update the related functions.
- Clean up database schema and data in test sql file.