### PR TITLE
Update version variable and command flag usage text

### DIFF
--- a/src/cmd/cmd.go
+++ b/src/cmd/cmd.go
@@ -11,7 +11,7 @@ func Execute() error {
 	app := &cli.App{
 		Name:    "go-xn",
 		Usage:   "The platform for publishing and running your blog",
-		Version: Version,
+		Version: version,
 		Commands: []*cli.Command{
 			webCmd,
 			updateCmd,

--- a/src/cmd/version.go
+++ b/src/cmd/version.go
@@ -12,7 +12,7 @@ import (
 // And export 'Version' variable
 // ⚠️ WARNING: should only be set by "-ldflags" cli flag.
 var (
-	Version   = ""
+	version   = ""
 	commitID  = ""
 	buildTime = ""
 
@@ -35,7 +35,7 @@ func showVersion(c *cli.Context) error {
 - Revision:   %s
 - OS/Arch:    %s/%s
 - Built time: %s
-`, Version, runtime.Version(), commitID,
+`, version, runtime.Version(), commitID,
 		runtime.GOOS, runtime.GOARCH, buildTime)
 
 	return nil

--- a/src/cmd/web.go
+++ b/src/cmd/web.go
@@ -28,7 +28,7 @@ If '--port' flag is not used, it will use port 7991 by default.`,
 	configFile = &cli.PathFlag{
 		Name:    "config",
 		Aliases: []string{"c"},
-		Usage:   "Custom configuration `file` path",
+		Usage:   "Custom configuration file path",
 		Value:   "fyj.ini",
 	}
 	port = &cli.IntFlag{

--- a/src/cmd/web.go
+++ b/src/cmd/web.go
@@ -26,10 +26,11 @@ If '--port' flag is not used, it will use port 7991 by default.`,
 	}
 
 	configFile = &cli.PathFlag{
-		Name:    "config",
-		Aliases: []string{"c"},
-		Usage:   "Custom configuration file path",
-		Value:   "fyj.ini",
+		Name:        "config",
+		Aliases:     []string{"c"},
+		Usage:       "Custom configuration file path",
+		Value:       "fyj.ini",
+		DefaultText: "fyj.ini",
 	}
 	port = &cli.IntFlag{
 		Name:    "port",
@@ -55,7 +56,7 @@ func runWeb(c *cli.Context) error {
 
 	err := route.InitRoutes()
 	if err != nil {
-		log.Fatalln("Fail to Start Web Server.", err)
+		log.Fatalln("fail to start web server:", err)
 	}
 
 	return err

--- a/src/cmd/web.go
+++ b/src/cmd/web.go
@@ -32,11 +32,10 @@ If '--port' flag is not used, it will use port 7991 by default.`,
 		Value:   "fyj.ini",
 	}
 	port = &cli.IntFlag{
-		Name:        "port",
-		Aliases:     []string{"p"},
-		Usage:       "Temporary port number to prevent conflict",
-		Value:       7991,
-		DefaultText: "7991",
+		Name:    "port",
+		Aliases: []string{"p"},
+		Usage:   "Temporary port number to prevent conflict",
+		Value:   7991,
 	}
 	debug = &cli.BoolFlag{
 		Name:               "debug",


### PR DESCRIPTION
- Rename exported `Version` variable to unexported `version`.
- Clean up `--config` flag usage text description for `web` subcommand, remove backticks.