### PR TITLE
fix: match `yaml` file extension with 2-space indentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,8 +12,8 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-# Matches the exact files either package.json or *.yml
-[{*.yml,package.json}]
+# Matches the exact files either package.json or *.y(a)ml
+[{*.yml,*.yaml,package.json}]
 indent_size = 2
 
 # Command `go fmt` set indent-style to TAB


### PR DESCRIPTION
> Fix [editorconfig](https://editorconfig.org/) constraints for `.yaml` extension files that failed to take effect.

Update `.editorconfig` file to include both `.yml` and `.yaml` file extensions for consistent YAML file formatting with 2-space indentation.