### PR TITLE
Implement agent command to run gRPC server

### DIFF
--- a/src/cmd/agent.go
+++ b/src/cmd/agent.go
@@ -2,8 +2,14 @@ package cmd
 
 import (
 	"fmt"
+	"log"
+	"net"
 
 	"github.com/urfave/cli/v2"
+	"google.golang.org/grpc"
+
+	"github.com/Pengxn/go-xn/src/rpc"
+	"github.com/Pengxn/go-xn/src/rpc/proto"
 )
 
 var (
@@ -25,7 +31,22 @@ It run as a gRPC server, it only support gRPC protocol.`,
 )
 
 func runGRPCServer(c *cli.Context) error {
-	// TODO: run gRPC server
-	fmt.Println(c.Int("port"))
+	port := c.Int("port")
+
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		log.Fatalf("failed to listen: %v", err)
+	}
+
+	gs := grpc.NewServer()
+	defer gs.Stop()
+	proto.RegisterHeathCheckServer(gs, &rpc.Server{})
+
+	log.Printf("server listening at %v", lis.Addr())
+	err = gs.Serve(lis)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
 	return nil
 }

--- a/src/rpc/server.go
+++ b/src/rpc/server.go
@@ -10,6 +10,6 @@ type Server struct {
 	pb.HeathCheckServer
 }
 
-func (s *Server) HeartBeat(_ context.Context, _ *pb.Empty) (*pb.Pong, error) {
+func (s *Server) Ping(_ context.Context, _ *pb.Empty) (*pb.Pong, error) {
 	return &pb.Pong{Message: "ok!"}, nil
 }


### PR DESCRIPTION
- Rename health check method from `HeartBeat` to `Ping` for server side.
- Add TCP listener setup and server initialization for gRPC server.
- Use `agent` command to run gRPC server, and implement health check service registration.