### PR TITLE
feat: add markdown render support by GitHub API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/go-sql-driver/mysql v1.8.1
 	github.com/go-webauthn/webauthn v0.11.2
 	github.com/golang-jwt/jwt/v5 v5.2.1
+	github.com/google/go-github/v69 v69.0.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/feeds v1.2.0
 	github.com/lib/pq v1.10.9
@@ -53,6 +54,7 @@ require (
 	github.com/go-webauthn/x v0.1.14 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
+	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/go-tpm v0.9.1 // indirect
 	github.com/gopherjs/gopherjs v1.17.2 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-sql-driver/mysql v1.8.1
 	github.com/go-webauthn/webauthn v0.11.2
 	github.com/golang-jwt/jwt/v5 v5.2.1
-	github.com/google/go-github/v69 v69.0.0
+	github.com/google/go-github/v69 v69.2.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/feeds v1.2.0
 	github.com/lib/pq v1.10.9

--- a/src/lib/github/github.go
+++ b/src/lib/github/github.go
@@ -1,0 +1,25 @@
+package github
+
+import (
+	"context"
+
+	"github.com/google/go-github/v69/github"
+)
+
+// Render renders the markdown text to HTML by GitHub API.
+// Default mode is "gfm" (GitHub Flavored Markdown),
+// refer to https://github.github.com/gfm/ for more details.
+func Render(text string) (string, error) {
+	client := github.NewClient(nil)
+
+	// API doc url: https://docs.github.com/en/rest/markdown/markdown
+	res, _, err := client.Markdown.Render(context.Background(), text, &github.MarkdownOptions{
+		Mode:    "gfm",
+		Context: "Pengxn/go-xn",
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return res, nil
+}


### PR DESCRIPTION
Add GitHub API markdown rendering functionality:
- Add `github.com/google/go-github/v69` dependency for GitHub API integration.
- Create a new package for GitHub markdown to HTML conversion.
- Use [GitHub Flavored Markdown (GFM)](https://github.github.com/gfm/) mode for rendering.