### PR TITLE
docs: update license copyright notice to include other contributors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2020 The Go-xn Author
+Copyright (c) 2020 The Go-xn Authors and Contributors
 
 This software is provided 'as-is', without any express or implied
 warranty. In no event will the authors be held liable for any damages


### PR DESCRIPTION
These changes properly acknowledge project other contributors in the `LICENSE` file.

```diff
-Copyright (c) 2020 The Go-xn Author
+Copyright (c) 2020 The Go-xn Authors and Contributors
```