### PR TITLE
ci: add macOS workflow to improve multi-platform testing and build

### DIFF
--- a/.github/workflows/test.macos.yml
+++ b/.github/workflows/test.macos.yml
@@ -1,7 +1,7 @@
 on: workflow_call
 
 jobs:
-  test-linux:
+  test-macos:
     name: Test on macOS
     runs-on: macos-latest
 

--- a/.github/workflows/test.macos.yml
+++ b/.github/workflows/test.macos.yml
@@ -1,0 +1,33 @@
+on: workflow_call
+
+jobs:
+  test-linux:
+    name: Test on macOS
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.23.x
+          cache: false
+
+      - name: Run tests
+        run: |
+          go mod download
+          go mod tidy
+          make test
+          make cover
+
+      - name: Compile and build
+        run: |
+          make
+
+      - name: Publish Build Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: darwin-amd64
+          path: build/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     uses: ./.github/workflows/test.windows.yml
 
   deploy-docker:
-    needs: test-linux
+    needs: [test-linux, test-macos]
     if: github.event_name == 'push' && github.ref_name == 'main'
     uses: ./.github/workflows/test.docker.yml
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ jobs:
   test-linux:
     uses: ./.github/workflows/test.linux.yml
 
+  test-macos:
+    uses: ./.github/workflows/test.macos.yml
+
   test-windows:
     uses: ./.github/workflows/test.windows.yml
 


### PR DESCRIPTION
- `test.yml`: update test workflow to include macOS builds.
- `test.macos.yml`: add macOS workflow support to test and build on `darwin/amd64`.
- Extend CI pipeline with `macos-latest` image on GitHub Actions.
- Improves cross-platform binary distribution capabilities.