### PR TITLE
ci: normalize artifact names using `runner` context variables

### DIFF
--- a/.github/workflows/test.linux.yml
+++ b/.github/workflows/test.linux.yml
@@ -29,5 +29,5 @@ jobs:
       - name: Publish Build Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: linux-amd64
+          name: ${{ runner.os }}-${{ runner.arch }}
           path: build/

--- a/.github/workflows/test.macos.yml
+++ b/.github/workflows/test.macos.yml
@@ -29,5 +29,5 @@ jobs:
       - name: Publish Build Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: darwin-arm64
+          name: ${{ runner.os }}-${{ runner.arch }}
           path: build/

--- a/.github/workflows/test.windows.yml
+++ b/.github/workflows/test.windows.yml
@@ -33,5 +33,5 @@ jobs:
       - name: Publish Build Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: windows-amd64
+          name: ${{ runner.os }}-${{ runner.arch }}
           path: build/


### PR DESCRIPTION
Standardize actions artifact naming across all platforms.
Replace platform-specific names with `runner` context variables.

For `runner` context, refer to [GitHub Actions - **runner** context](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#runner-context)