### PR TITLE
Separate windows build artifacts for binary and installer

### DIFF
--- a/.github/workflows/test.windows.yml
+++ b/.github/workflows/test.windows.yml
@@ -26,12 +26,18 @@ jobs:
         run: |
           make
 
-      - name: Build Inno Setup Installer
-        run: |
-          iscc .\script\windows\go-xn.iss
-
       - name: Publish Build Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ${{ runner.os }}-${{ runner.arch }}
           path: build/
+
+      - name: Build Inno Setup Installer
+        run: |
+          iscc .\script\windows\go-xn.iss
+
+      - name: Publish Installer Build Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ runner.os }}-${{ runner.arch }}-installer
+          path: build/dist/*.exe


### PR DESCRIPTION
Split windows build artifacts into two separate uploads,
one for the compiled binary files and another for the [inno-setup] installer.

[inno-setup]: https://github.com/jrsoftware/issrc