### PR TITLE
ci: export platform-related env variables and use them as artifact names 

### DIFF
--- a/.github/workflows/test.docker.yml
+++ b/.github/workflows/test.docker.yml
@@ -36,6 +36,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Set GCHR_USER Environment Variable
         run: |
           echo "GCHR_USER=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV

--- a/.github/workflows/test.linux.yml
+++ b/.github/workflows/test.linux.yml
@@ -14,6 +14,9 @@ jobs:
         with:
           go-version: 1.23.x
           cache: false
+        run: |
+          echo "GOOS=$(go env GOOS)" >> $GITHUB_ENV
+          echo "GOARCH=$(go env GOARCH)" >> $GITHUB_ENV
 
       - name: Run tests
         run: |
@@ -29,5 +32,5 @@ jobs:
       - name: Publish Build Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ runner.os }}-${{ runner.arch }}
+          name: ${{ env.GOOS }}-${{ env.GOARCH }}
           path: build/

--- a/.github/workflows/test.linux.yml
+++ b/.github/workflows/test.linux.yml
@@ -14,6 +14,8 @@ jobs:
         with:
           go-version: 1.23.x
           cache: false
+
+      - name: Set environment variables
         run: |
           echo "GOOS=$(go env GOOS)" >> $GITHUB_ENV
           echo "GOARCH=$(go env GOARCH)" >> $GITHUB_ENV

--- a/.github/workflows/test.macos.yml
+++ b/.github/workflows/test.macos.yml
@@ -14,6 +14,9 @@ jobs:
         with:
           go-version: 1.23.x
           cache: false
+        run: |
+          echo "GOOS=$(go env GOOS)" >> $GITHUB_ENV
+          echo "GOARCH=$(go env GOARCH)" >> $GITHUB_ENV
 
       - name: Run tests
         run: |
@@ -29,5 +32,5 @@ jobs:
       - name: Publish Build Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ runner.os }}-${{ runner.arch }}
+          name: ${{ env.GOOS }}-${{ env.GOARCH }}
           path: build/

--- a/.github/workflows/test.macos.yml
+++ b/.github/workflows/test.macos.yml
@@ -14,6 +14,8 @@ jobs:
         with:
           go-version: 1.23.x
           cache: false
+
+      - name: Set environment variables
         run: |
           echo "GOOS=$(go env GOOS)" >> $GITHUB_ENV
           echo "GOARCH=$(go env GOARCH)" >> $GITHUB_ENV

--- a/.github/workflows/test.windows.yml
+++ b/.github/workflows/test.windows.yml
@@ -14,6 +14,8 @@ jobs:
         with:
           go-version: 1.23.x
           cache: false
+
+      - name: Set environment variables
         run: |
           echo "GOOS=$(go env GOOS)" >> $GITHUB_ENV
           echo "GOARCH=$(go env GOARCH)" >> $GITHUB_ENV

--- a/.github/workflows/test.windows.yml
+++ b/.github/workflows/test.windows.yml
@@ -14,6 +14,9 @@ jobs:
         with:
           go-version: 1.23.x
           cache: false
+        run: |
+          echo "GOOS=$(go env GOOS)" >> $GITHUB_ENV
+          echo "GOARCH=$(go env GOARCH)" >> $GITHUB_ENV
 
       - name: Run tests
         run: |
@@ -29,7 +32,7 @@ jobs:
       - name: Publish Build Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ runner.os }}-${{ runner.arch }}
+          name: ${{ env.GOOS }}-${{ env.GOARCH }}
           path: build/
 
       - name: Build Inno Setup Installer
@@ -39,5 +42,5 @@ jobs:
       - name: Publish Installer Build Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ runner.os }}-${{ runner.arch }}-installer
+          name: ${{ env.GOOS }}-${{ env.GOARCH }}-installer
           path: build/dist/*.exe

--- a/.github/workflows/test.windows.yml
+++ b/.github/workflows/test.windows.yml
@@ -17,8 +17,8 @@ jobs:
 
       - name: Set environment variables
         run: |
-          echo "GOOS=$(go env GOOS)" >> $GITHUB_ENV
-          echo "GOARCH=$(go env GOARCH)" >> $GITHUB_ENV
+          echo "GOOS=$(go env GOOS)" >> $env:GITHUB_ENV
+          echo "GOARCH=$(go env GOARCH)" >> $env:GITHUB_ENV
 
       - name: Run tests
         run: |


### PR DESCRIPTION
Export environment variables `GOOS` and `GOARCH` from `go env` and use them for artifact naming in workflows.
Name build artifacts to follow the platform naming conventions used by `go env`.

refer to [GitHub Docs - Workflow Commands #Setting an environment variable](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable)