### PR TITLE
Update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,21 @@
-# Set update schedule for gomod
+# Set update schedule for dependabot
 
 version: 2
 updates:
+  # Go modules
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "daily"
     labels:
       - "dependencies 📦"
+    target-branch: "main"
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies 📦"
+      - "CI/CD ⚙️"
     target-branch: "main"


### PR DESCRIPTION
Add **`github-actions`** update schedule to dependabot, refer to [GitHub Docs #Dependabot options reference](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#github-actions).
Check and trigger dependabot updates for github actions weekly, and label `dependencies 📦` and `CI/CD ⚙️` tags accordingly.