### PR TITLE
Update build installer output path

### DIFF
--- a/.github/workflows/test.windows.yml
+++ b/.github/workflows/test.windows.yml
@@ -45,4 +45,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.GOOS }}-${{ env.GOARCH }}-installer
-          path: build/dist/*.exe
+          path: build/*-setup.exe

--- a/.github/workflows/test.windows.yml
+++ b/.github/workflows/test.windows.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Build Inno Setup Installer
         run: |
-          iscc .\script\windows\go-xn.iss
+          iscc script/windows/go-xn.iss
 
       - name: Publish Installer Build Artifacts
         uses: actions/upload-artifact@v4

--- a/script/windows/go-xn.iss
+++ b/script/windows/go-xn.iss
@@ -11,7 +11,7 @@
 #define EXE_NAME 'go-xn.exe'
 #define ICON '..\..\web\icons\xn-02f.ico'
 #define LICENSE '..\..\LICENSE'
-#define OUTPUT_DIR '..\..\build\dist'
+#define OUTPUT_DIR '..\..\build'
 #define OUTPUT_NAME 'go-xn-setup'
 
 [Setup]


### PR DESCRIPTION
- Change the build installer output directory from `build/dist` to `build`.
- Update the artifact path pattern `build/*-setup.exe` to match the new location in windows test workflow.
- Replace windows-style backslash `\` path separator with uniform forward slash `/` in the inno-setup compiler command.