### PR TITLE
Use github latest asset link as update source

### DIFF
--- a/src/cmd/update.go
+++ b/src/cmd/update.go
@@ -15,9 +15,6 @@ import (
 )
 
 var (
-	// nightly.link is a service to provide nightly build artifact download link.
-	nightlyURL = "https://nightly.link/Pengxn/go-xn/workflows/test/main"
-
 	// Update is "update" subcommand.
 	// It's used to update command binary to the latest version.
 	updateCmd = &cli.Command{

--- a/src/cmd/update.go
+++ b/src/cmd/update.go
@@ -3,15 +3,14 @@ package cmd
 import (
 	"archive/zip"
 	"bytes"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 
 	"github.com/schollz/progressbar/v3"
 	"github.com/urfave/cli/v2"
 
+	"github.com/Pengxn/go-xn/src/lib/github"
 	"github.com/Pengxn/go-xn/src/util/httplib"
 )
 
@@ -29,7 +28,11 @@ var (
 )
 
 func update(c *cli.Context) error {
-	link := fmt.Sprintf("%s/%s-%s.zip", nightlyURL, runtime.GOOS, runtime.GOARCH)
+	link, err := github.GetLatestAssetLink()
+	if err != nil {
+		return err
+	}
+
 	resp, err := httplib.New().GET(link)
 	if err != nil {
 		return err

--- a/src/lib/github/github.go
+++ b/src/lib/github/github.go
@@ -2,8 +2,17 @@ package github
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"runtime"
+	"strings"
 
 	"github.com/google/go-github/v69/github"
+)
+
+var (
+	defaultOwner = "Pengxn"
+	defaultRepo  = "go-xn"
 )
 
 // Render renders the markdown text to HTML by GitHub API.
@@ -15,11 +24,33 @@ func Render(text string) (string, error) {
 	// API doc url: https://docs.github.com/en/rest/markdown/markdown
 	res, _, err := client.Markdown.Render(context.Background(), text, &github.MarkdownOptions{
 		Mode:    "gfm",
-		Context: "Pengxn/go-xn",
+		Context: defaultOwner + "/" + defaultRepo,
 	})
 	if err != nil {
 		return "", err
 	}
 
 	return res, nil
+}
+
+// GetLatestAssetLink returns the latest asset link of the release from GitHub.
+// It requires the owner and repo name of the repository.
+// The asset link is the download URL of the asset file for the current os and arch.
+func GetLatestAssetLink() (string, error) {
+	client := github.NewClient(nil)
+
+	// API doc url: https://docs.github.com/en/rest/releases/releases#get-the-latest-release
+	rel, _, err := client.Repositories.GetLatestRelease(context.Background(), defaultOwner, defaultRepo)
+	if err != nil {
+		return "", err
+	}
+
+	substr := fmt.Sprintf("-%s-%s.", runtime.GOOS, runtime.GOARCH)
+	for _, asset := range rel.Assets {
+		if strings.Contains(asset.GetName(), substr) {
+			return asset.GetBrowserDownloadURL(), nil
+		}
+	}
+
+	return "", errors.New("no latest asset link found")
 }


### PR DESCRIPTION
- Add new `GetLatestAssetLink()` function to find the latest platform-specific asset link from latest release.
- Modify `update` command to use github latest asset link instead of nightly.link URL.
- Define `defaultOwner` and `defaultRepo` as common variables for arguments with the go-github client.