### PR TITLE
Initialize slog with `tint` handler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/feeds v1.2.0
 	github.com/lib/pq v1.10.9
+	github.com/lmittmann/tint v1.0.7
 	github.com/mattn/go-sqlite3 v1.14.24
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pquerna/otp v1.4.0

--- a/src/util/log/slog/slog.go
+++ b/src/util/log/slog/slog.go
@@ -1,0 +1,17 @@
+package slogger
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/lmittmann/tint"
+)
+
+func init() {
+	logger := slog.New(tint.NewHandler(os.Stderr, &tint.Options{
+		Level:      slog.LevelDebug,
+		TimeFormat: "2006/01/02 - 15:04:05",
+	}))
+
+	slog.SetDefault(logger)
+}


### PR DESCRIPTION
- Add `github.com/lmittmann/tint` dependency package to `go.mod` file.
- Initialize `slog` default logger with [`tint`](https://github.com/lmittmann/tint) handler and write to `os.Stderr`.
- Configure handler with debug level `slog.LevelDebug` logging and custom time format `2006/01/02 - 15:04:05`.