### PR TITLE
Add `--nightly` flag to support switching to nightly build

### DIFF
--- a/src/cmd/update.go
+++ b/src/cmd/update.go
@@ -21,11 +21,28 @@ var (
 		Name:   "update",
 		Usage:  "Update the binary to the latest version",
 		Action: update,
+		Flags:  []cli.Flag{nightlyFlag},
+	}
+
+	// nightlyFlag is a flag to specify updating to the latest nightly build.
+	nightlyFlag = &cli.BoolFlag{
+		Name:               "nightly",
+		Aliases:            []string{"n"},
+		Usage:              "Update to the latest nightly build",
+		DisableDefaultText: true,
 	}
 )
 
 func update(c *cli.Context) error {
-	link, err := github.GetLatestAssetLink()
+	var (
+		link string
+		err  error
+	)
+	if c.Bool("nightly") {
+		link, err = github.GetActionsArtifactLink()
+	} else {
+		link, err = github.GetLatestAssetLink()
+	}
 	if err != nil {
 		return err
 	}

--- a/src/cmd/update.go
+++ b/src/cmd/update.go
@@ -39,7 +39,7 @@ func update(c *cli.Context) error {
 		err  error
 	)
 	if c.Bool("nightly") {
-		link, err = github.GetActionsArtifactLink()
+		link, err = github.GetNightlyLink()
 	} else {
 		link, err = github.GetLatestAssetLink()
 	}

--- a/src/lib/github/github.go
+++ b/src/lib/github/github.go
@@ -59,9 +59,7 @@ func GetLatestAssetLink() (string, error) {
 // GetActionsArtifactLink returns the latest artifact link of the workflow run from GitHub Actions.
 // It requires the owner and repo name of the repository, and the branch name.
 // The artifact link is the download URL of the artifact file for the current os and arch.
-//
-// But it requires authentication with `actions:read` scope to access the archived artifacts links.
-func GetActionsArtifactLink() (string, string, error) {
+func GetActionsArtifactLink() (string, error) {
 	client := github.NewClient(nil)
 	ctx := context.Background()
 
@@ -69,11 +67,11 @@ func GetActionsArtifactLink() (string, string, error) {
 	option := &github.ListWorkflowRunsOptions{Branch: defaultBranch}
 	runs, _, err := client.Actions.ListRepositoryWorkflowRuns(ctx, defaultOwner, defaultRepo, option)
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 
 	if len(runs.WorkflowRuns) == 0 {
-		return "", "", errors.New("no latest workflow runs found")
+		return "", errors.New("no latest workflow runs found")
 	}
 
 	runID := runs.WorkflowRuns[0].GetID()
@@ -81,21 +79,20 @@ func GetActionsArtifactLink() (string, string, error) {
 	// API doc url: https://docs.github.com/en/rest/actions/artifacts#list-workflow-run-artifacts
 	artifacts, _, err := client.Actions.ListWorkflowRunArtifacts(ctx, defaultOwner, defaultRepo, runID, nil)
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 
-	var archive, artifactName string
+	var archive string
 	for _, artifact := range artifacts.Artifacts {
 		if artifact.GetName() == runtime.GOOS+"-"+runtime.GOARCH {
 			archive = artifact.GetArchiveDownloadURL()
-			artifactName = artifact.GetName()
 			break
 		}
 	}
 
 	if archive == "" {
-		return "", "", errors.New("no latest artifact link found")
+		return "", errors.New("no latest artifact link found")
 	}
 
-	return archive, artifactName, nil
+	return archive, nil
 }

--- a/src/lib/github/github.go
+++ b/src/lib/github/github.go
@@ -56,10 +56,25 @@ func GetLatestAssetLink() (string, error) {
 	return "", errors.New("no latest asset link found")
 }
 
+// GetNightlyLink returns the nightly build artifact link from nightly.link.
+func GetNightlyLink() (string, error) {
+	_, artifactName, err := GetActionsArtifactLink()
+	if err != nil {
+		return "", err
+	}
+
+	// nightly.link is a service to provide nightly build artifact download link.
+	nightlyURL := "https://nightly.link/Pengxn/go-xn/workflows/test/main"
+
+	return fmt.Sprintf("%s/%s.zip", nightlyURL, artifactName), nil
+}
+
 // GetActionsArtifactLink returns the latest artifact link of the workflow run from GitHub Actions.
 // It requires the owner and repo name of the repository, and the branch name.
 // The artifact link is the download URL of the artifact file for the current os and arch.
-func GetActionsArtifactLink() (string, error) {
+//
+// But it requires authentication with `actions:read` scope to access the archived artifacts links.
+func GetActionsArtifactLink() (string, string, error) {
 	client := github.NewClient(nil)
 	ctx := context.Background()
 
@@ -67,32 +82,36 @@ func GetActionsArtifactLink() (string, error) {
 	option := &github.ListWorkflowRunsOptions{Branch: defaultBranch}
 	runs, _, err := client.Actions.ListRepositoryWorkflowRuns(ctx, defaultOwner, defaultRepo, option)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	if len(runs.WorkflowRuns) == 0 {
-		return "", errors.New("no latest workflow runs found")
+		return "", "", errors.New("no latest workflow runs found")
 	}
 
 	runID := runs.WorkflowRuns[0].GetID()
 
+	// TODO: check the status of the workflow run, if it's `in_progress` to detect the latest artifact.
+	// If `in_progress` workflow run not found, then get the latest completed workflow run.
+
 	// API doc url: https://docs.github.com/en/rest/actions/artifacts#list-workflow-run-artifacts
 	artifacts, _, err := client.Actions.ListWorkflowRunArtifacts(ctx, defaultOwner, defaultRepo, runID, nil)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
-	var archive string
+	var archive, artifactName string
 	for _, artifact := range artifacts.Artifacts {
 		if artifact.GetName() == runtime.GOOS+"-"+runtime.GOARCH {
 			archive = artifact.GetArchiveDownloadURL()
+			artifactName = artifact.GetName()
 			break
 		}
 	}
 
 	if archive == "" {
-		return "", errors.New("no latest artifact link found")
+		return "", "", errors.New("no latest artifact link found")
 	}
 
-	return archive, nil
+	return archive, artifactName, nil
 }


### PR DESCRIPTION
- Add `--nightly`/`-n` flag to the `update` subcommand, allowing users to update to the latest nightly build.
- Update the update logic to support fetching stable or nightly builds based on user choice.
- Add `GetNightlyLink()` to provide nightly build artifact download link from nightly.link service.

> GitHub actions archived artifact download links require authentication with the `actions` scope,
> so use the latest nightly build link instead.