### PR TITLE
Bump go toolchain version to `1.24`

### DIFF
--- a/.github/workflows/test.linux.yml
+++ b/.github/workflows/test.linux.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.x
+          go-version: 1.24.x
           cache: false
 
       - name: Set environment variables

--- a/.github/workflows/test.macos.yml
+++ b/.github/workflows/test.macos.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.x
+          go-version: 1.24.x
           cache: false
 
       - name: Set environment variables

--- a/.github/workflows/test.windows.yml
+++ b/.github/workflows/test.windows.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.x
+          go-version: 1.24.x
           cache: false
 
       - name: Set environment variables

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,8 @@ require (
 	xorm.io/xorm v1.3.9
 )
 
-go 1.23
+go 1.24
+
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc // indirect

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-//go:build go1.23
+//go:build go1.24
 
 // Copyright 2020 The Go-xn Authors. All rights reserved.
 // Use of this source code is governed by a Zlib license


### PR DESCRIPTION
- Upgrade go toolchain version to `1.24` in `go.mod` file.
- Update go version to `1.24.x` for GitHub Actions.