### PR TITLE
fix: skip dependabot workflow runs when retrieving artifacts

### DIFF
--- a/src/lib/github/github.go
+++ b/src/lib/github/github.go
@@ -45,7 +45,7 @@ func GetLatestAssetLink() (string, error) {
 	if err != nil {
 		return "", err
 	}
-
+	// release asset name suffix, e.g. <name>-<version>-linux-amd64.tar.gz
 	substr := fmt.Sprintf("-%s-%s.", runtime.GOOS, runtime.GOARCH)
 	for _, asset := range rel.Assets {
 		if strings.Contains(asset.GetName(), substr) {
@@ -88,6 +88,11 @@ func GetActionsArtifactLink() (string, string, error) {
 
 	var runID int64
 	for _, run := range runs.WorkflowRuns {
+		// Skip the `Dependabot Updates` workflow runs, as they are not the nightly build.
+		// Its complete path is `dynamic/dependabot/dependabot-updates`.
+		if strings.Contains(run.GetPath(), "dependabot") {
+			continue
+		}
 		if run.GetStatus() == "completed" {
 			runID = run.GetID()
 			break


### PR DESCRIPTION
Add filtering to skip `Dependabot Updates` workflow runs when retrieving artifacts,
preventing the workflow run link from being selected without building artifacts.
The `Dependabot Updates` workflow run is not the nightly build, it's used for updating dependencies,
and its `run.GetPath()` complete path is `dynamic/dependabot/dependabot-updates`.

Add a clarifying comment about the release asset name format, e.g., `<name>-<version>-linux-amd64.tar.gz`.