### PR TITLE
Add `ping` subcommand to check agent server status

### DIFF
--- a/src/cmd/agent.go
+++ b/src/cmd/agent.go
@@ -21,6 +21,21 @@ var (
 		Description: `Run a gRPC serveras an agent side, it only support gRPC protocol.`,
 		Flags:       []cli.Flag{agentPort},
 		Action:      runGRPCServer,
+		Subcommands: []*cli.Command{agentPingCmd},
+	}
+	agentPingCmd = &cli.Command{
+		Name:        "ping",
+		Usage:       "Ping the agent",
+		Description: `Ping the agent, which can be used to check the agent status.`,
+		Flags:       []cli.Flag{pingUrl},
+		Action:      pingAgent,
+	}
+
+	pingUrl = &cli.StringFlag{
+		Name:    "url",
+		Aliases: []string{"u"},
+		Usage:   "URL to ping",
+		Value:   "127.0.0.1:7992",
 	}
 
 	agentPort = &cli.IntFlag{
@@ -46,6 +61,17 @@ func runGRPCServer(c *cli.Context) error {
 	if err != nil {
 		log.Fatalln(err)
 	}
+
+	return nil
+}
+
+func pingAgent(c *cli.Context) error {
+	pong, err := rpc.Client(c.String("url"))
+	if err != nil {
+		log.Fatalln("failed to ping agent:", err)
+	}
+
+	fmt.Println(pong.Message)
 
 	return nil
 }


### PR DESCRIPTION
- Add `ping` subcommand for the `agent` command.
- The `ping` subcommand can be used to check the agent server status.
- Add `--url`/`-u` flag to specify the agent server URL, its default value is **127.0.0.1:7992**.