### PR TITLE
Add support for funding manifest and discovery

### DIFF
--- a/src/route/static.go
+++ b/src/route/static.go
@@ -35,6 +35,10 @@ func staticRoutes(g *gin.Engine) {
 	staticFile(g, "/.well-known/security.txt", "security.txt", localFS, otherFS)
 	// keybase.txt, refer to: https://keybase.io/docs/keybase_well_known
 	staticFile(g, "/.well-known/keybase.txt", "keybase.txt", localFS, otherFS)
+
+	// floss.fund, refer to: https://floss.fund/funding-manifest/
+	staticFile(g, "/.well-known/funding-manifest-urls", "funding-manifest-urls", localFS, otherFS)
+	staticFile(g, "/funding.json", "funding.json", localFS, otherFS)
 }
 
 func staticFile(g *gin.Engine, relativePath, filepath string, fsys ...http.FileSystem) {


### PR DESCRIPTION
Add static route for `/.well-known/funding-manifest-urls` and `/funding.json` file from multiple file systems.

- `funding.json` is an open manifest (JSON schema) that acts as a signaling and discovery mechanism for projects seeking funding. 
- `funding-manifest-urls` is a text file that contains URL (one or more) pointing to the `funding.json` file, which follows the [`.well-known` convention](https://datatracker.ietf.org/doc/html/rfc8615).

refer to [funding.json manifest](https://floss.fund/funding-manifest/)