### PR TITLE
Add tool dependencies to `tool` directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,11 @@ require (
 
 go 1.24
 
+tool (
+	google.golang.org/grpc/cmd/protoc-gen-go-grpc
+	google.golang.org/protobuf/cmd/protoc-gen-go
+)
+
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc // indirect
@@ -80,6 +85,7 @@ require (
 	golang.org/x/term v0.30.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250115164207-1a7da9e5054f // indirect
+	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.5.1 // indirect
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
 	gopkg.in/mail.v2 v2.3.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect


### PR DESCRIPTION
Add tool dependencies used with `go tool` command, refer to [Managing dependencies: tool dependencies].
For go 1.24 and above, you can add the `tool` directive to the `go.mod` file to manage the tools used in the project, refer to [go 1.24 release notes] and [go module tool directive].

---------

Run the below command to add `tool` directive to go.mod file:
```shell
go get -tool google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
go get -tool google.golang.org/protobuf/cmd/protoc-gen-go@latest
```

You can validate those tools have been installed by running:
```shell
go tool protoc-gen-go-grpc --version
go tool protoc-gen-go --version

# it will print the following info:
# protoc-gen-go-grpc 1.5.1
# protoc-gen-go.exe v1.36.5
```

[go 1.24 release notes]: https://go.dev/doc/go1.24#go-command
[Managing dependencies: tool dependencies]: https://go.dev/doc/modules/managing-dependencies#tools
[go module tool directive]: https://go.dev/ref/mod#go-mod-file-tool