### PR TITLE
Fix whois server extraction regex

### DIFF
--- a/src/lib/whois/whois.go
+++ b/src/lib/whois/whois.go
@@ -44,7 +44,7 @@ func getWhoisServer(domain string) (string, error) {
 		return "", err
 	}
 
-	ret := regexp.MustCompile("(?i:<b>WHOIS Server:</b>(.*?)\n)").FindStringSubmatch(string(bodyData))
+	ret := regexp.MustCompile("(?i:<b>WHOIS Server:</b>(.*?)<br>)").FindStringSubmatch(string(bodyData))
 
 	return strings.TrimSpace(ret[1]), nil
 }


### PR DESCRIPTION
Fix parsing issues with the top-level domain whois server address retrieval, use `<br>` tag instead of `\n`.

The whois server extraction regular expression has not been working since the IANA page changed its source html code,
the `\n` newline character was replaced by the `<br>` html tag.

relate to issue #419