### PR TITLE
Remove unused dns related configuration

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -43,7 +43,6 @@ type appConfig struct {
 	Server   ServerConfig   `ini:"server"`
 	DB       DBConfig       `ini:"database"`
 	Redis    RedisConfig    `ini:"redis"`
-	DNS      DNSConfig      `ini:"dns"`
 	Sentry   SentryConfig   `ini:"sentry"`
 	Logger   LoggerConfig   `ini:"log"`
 	WebAuthn WebAuthnConfig `ini:"webauthn"`
@@ -78,12 +77,6 @@ type RedisConfig struct {
 	Username string `ini:"username"`
 	Password string `ini:"password"`
 	DB       int    `ini:"db"`
-}
-
-// DNSConfig is DNS configuration for Tencent Cloud.
-type DNSConfig struct {
-	SecretID  string `ini:"secretID"`
-	SecretKey string `ini:"secretKey"`
 }
 
 // SentryConfig is configuration for Sentry.

--- a/src/config/example.ini
+++ b/src/config/example.ini
@@ -29,10 +29,6 @@ db       = 0              # redis db  (default: 0)
 DSN   = https://xxx@sentry.io/xxx # sentry DSN
 debug = false                     # enable sentry debug (default: false)
 
-[dns]
-secretID  = AKIDAF*** ***Z0Gno6C
-secretKey = IdxgOu*** ***Fj2CFYJ
-
 [log]
 level = INFO      # log level: DEBUG, INFO, WARN, ERROR, FATAL (default: INFO)
 app   = app.log   # log path for server                        (default: app.log)


### PR DESCRIPTION
- Remove `DNSConfig` struct from config.
- Remove `dns` section from example config file.

The dns config has been used in `github.com/Pengxn/go-xn/src/lib/dns` package,
but the `dns` package has been removed in PR #410.