### PR TITLE
Deprecated `LogFilePath` function and remove calling it

### DIFF
--- a/src/middleware/logger.go
+++ b/src/middleware/logger.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -51,11 +52,7 @@ func writerLog() io.Writer {
 		return os.Stdout
 	}
 
-	logFile, err := log.LogFilePath("route.log")
-	if err != nil {
-		log.Errorf("get log file Path %s error: %v", logFile, err)
-		return os.Stdout
-	}
+	logFile := filepath.Join("logs", "route.log") // -> ./logs/route.log
 
 	// Logging to a file, append logging if the file already exists.
 	f, err := os.OpenFile(logFile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)

--- a/src/util/log/writer.go
+++ b/src/util/log/writer.go
@@ -28,6 +28,10 @@ func writerLog() io.Writer {
 	return f
 }
 
+// LogFilePath returns the log file path.
+//
+// Deprecated: use fixed log file name instead, with `./logs` directory.
+// This function is deprecated and will be removed in the future.
 func LogFilePath(fileName string) (string, error) {
 	if file.IsExist(fileName) && file.IsFile(fileName) {
 		return fileName, nil // => ./<logFile>

--- a/src/util/log/writer.go
+++ b/src/util/log/writer.go
@@ -12,11 +12,7 @@ import (
 // writerLog writes log to the specified writer buffer.
 // Example: os.Stderr, a file opened in write mode, a socket...
 func writerLog() io.Writer {
-	logFile, err := LogFilePath("fyj.log")
-	if err != nil {
-		log.Printf("get log file Path %s error: %v", logFile, err)
-		return os.Stderr
-	}
+	logFile := filepath.Join("logs", "fyj.log") // -> ./logs/fyj.log
 
 	// Logging to a file, append logging if the file already exists.
 	f, err := os.OpenFile(logFile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
@@ -31,7 +27,7 @@ func writerLog() io.Writer {
 // LogFilePath returns the log file path.
 //
 // Deprecated: use fixed log file name instead, with `./logs` directory.
-// This function is deprecated and will be removed in the future.
+// This function is deprecated and will be removed in the next release.
 func LogFilePath(fileName string) (string, error) {
 	if file.IsExist(fileName) && file.IsFile(fileName) {
 		return fileName, nil // => ./<logFile>


### PR DESCRIPTION
- Add doc comments to mark `LogFilePath()` function as deprecated, and note that it will be removed in the next release.
- Remove the calling `LogFilePath` function and use fixed log file name instead.