### PR TITLE
Switch to std `log/slog` package for structured logging

### DIFF
--- a/src/cmd/web.go
+++ b/src/cmd/web.go
@@ -1,13 +1,14 @@
 package cmd
 
 import (
+	"log"
+
 	"github.com/urfave/cli/v2"
 
 	"github.com/Pengxn/go-xn/src/config"
 	"github.com/Pengxn/go-xn/src/lib/webauthn"
 	"github.com/Pengxn/go-xn/src/model"
 	"github.com/Pengxn/go-xn/src/route"
-	"github.com/Pengxn/go-xn/src/util/log"
 )
 
 var (
@@ -56,7 +57,7 @@ func runWeb(c *cli.Context) error {
 
 	err := route.InitRoutes()
 	if err != nil {
-		log.Fatalln("fail to start web server:", err)
+		log.Fatalln("fail to init routes", err)
 	}
 
 	return err

--- a/src/config/cmd.go
+++ b/src/config/cmd.go
@@ -1,22 +1,22 @@
 package config
 
 import (
+	"log/slog"
 	"os"
 
 	"github.com/urfave/cli/v2"
 
 	"github.com/Pengxn/go-xn/src/util/file"
-	"github.com/Pengxn/go-xn/src/util/log"
 )
 
 func OverrideConfigByFlag(c *cli.Context) {
 	if c.IsSet("config") { // specified config file
 		f := c.Path("config")
 		if !file.IsExist(f) || !file.IsFile(f) {
-			log.Error("Specified config file not found: " + f)
+			slog.Error("specified config file not found", slog.String("filename", f))
 		}
 		if err := loadConfig(f); err != nil {
-			log.Errorf("Load specified config file failed, %+v", err)
+			slog.Error("load specified config file failed", slog.Any("error", err))
 		}
 	}
 	// Server config

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -1,10 +1,10 @@
 package config
 
 import (
+	"log/slog"
+
 	"github.com/go-ini/ini"
 	"github.com/google/uuid"
-
-	"github.com/Pengxn/go-xn/src/util/log"
 )
 
 var Config appConfig // Global config object
@@ -21,7 +21,7 @@ func init() {
 	}
 
 	if err := loadConfig(configPath); err != nil {
-		log.Errorf("Load config file failed, %+v", err)
+		slog.Error("load config file failed", slog.Any("error", err))
 	}
 }
 

--- a/src/controller/article.go
+++ b/src/controller/article.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"html/template"
+	"log/slog"
 	"strconv"
 	"time"
 
@@ -9,7 +10,6 @@ import (
 
 	"github.com/Pengxn/go-xn/src/lib/markdown"
 	"github.com/Pengxn/go-xn/src/model"
-	"github.com/Pengxn/go-xn/src/util/log"
 )
 
 // DefaultPageLimit is default limit number per page,
@@ -81,7 +81,7 @@ func GetArticle(c *gin.Context) {
 
 	content, err := markdown.ToHTML([]byte(article.Content))
 	if err != nil {
-		log.Errorf("convert markdown to HTML error: %+v", err)
+		slog.Error("convert markdown to HTML error", slog.Any("error", err))
 		c.JSON(500, gin.H{
 			"code": 500,
 			"data": "Convert markdown to HTML failed",

--- a/src/controller/option.go
+++ b/src/controller/option.go
@@ -1,13 +1,13 @@
 package controller
 
 import (
+	"log/slog"
 	"strings"
 
 	"github.com/gin-gonic/gin"
 	"xorm.io/xorm"
 
 	"github.com/Pengxn/go-xn/src/model"
-	"github.com/Pengxn/go-xn/src/util/log"
 )
 
 // ListOptions returns all options.
@@ -17,7 +17,7 @@ import (
 func ListOptions(c *gin.Context) {
 	list, err := model.GetAllOptions()
 	if err != nil {
-		log.Errorf("ListOptions: %s", err)
+		slog.Error("ListOptions", slog.Any("error", err))
 		errorJSON(c, 500, "failed to get options")
 		return
 	}
@@ -43,7 +43,7 @@ func GetOption(c *gin.Context) {
 
 	has, option, err := model.GetOptionByName(name)
 	if err != nil {
-		log.Errorf("GetOption: %s", err)
+		slog.Error("GetOption", slog.Any("error", err))
 		errorJSON(c, 500, "failed to get option data")
 		return
 	}
@@ -74,7 +74,7 @@ func InsertOption(c *gin.Context) {
 
 	success, err := model.AddOption(&model.Option{Name: name, Value: string(value)})
 	if err != nil || !success {
-		log.Errorf("InsertOption: %s", err)
+		slog.Error("InsertOption", slog.Any("error", err))
 		errorJSON(c, 500, "failed to insert option data")
 		return
 	}
@@ -100,7 +100,7 @@ func UpdateOption(c *gin.Context) {
 		return
 	}
 	if err != nil || !success {
-		log.Errorf("UpdateOption: %s", err)
+		slog.Error("UpdateOption", slog.Any("error", err))
 		errorJSON(c, 500, "update option data failed")
 		return
 	}
@@ -125,7 +125,7 @@ func DeleteOption(c *gin.Context) {
 		return
 	}
 	if err != nil || !success {
-		log.Errorf("DeleteOption: %s", err)
+		slog.Error("DeleteOption", slog.Any("error", err))
 		errorJSON(c, 500, "delete option data failed")
 		return
 	}

--- a/src/controller/others.go
+++ b/src/controller/others.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"fmt"
 	"html/template"
+	"log/slog"
 	"os"
 	"strings"
 	"time"
@@ -13,7 +14,6 @@ import (
 
 	"github.com/Pengxn/go-xn/src/lib/markdown"
 	"github.com/Pengxn/go-xn/src/lib/whois"
-	"github.com/Pengxn/go-xn/src/util/log"
 )
 
 // GwtWhoisInfo gets domain whois information.
@@ -30,14 +30,14 @@ func GwtWhoisInfo(c *gin.Context) {
 	// Convert domain to punycode if it includes non-ASCII characters
 	domain, err := idna.ToASCII(domain)
 	if err != nil {
-		log.Errorf("convert punycode error: %+v, domain: %s", err, domain)
+		slog.Error("convert punycode error", slog.Any("error", err), slog.String("domain", domain))
 		c.String(403, err.Error())
 		return
 	}
 
 	res, err := whois.GetWhois(domain)
 	if err != nil {
-		log.Errorf("Get Whois Information error: %+v, domain: %s", err, domain)
+		slog.Error("get Whois Information error", slog.Any("error", err), slog.String("domain", domain))
 		c.String(404, err.Error())
 		return
 	}
@@ -51,7 +51,7 @@ func GwtWhoisInfo(c *gin.Context) {
 func UploadFileForUPic(c *gin.Context) {
 	file, err := c.FormFile("file")
 	if err != nil {
-		log.Errorf("Get uploaded file error: %+v", err)
+		slog.Error("get uploaded file error", slog.Any("error", err))
 		c.JSON(500, gin.H{
 			"code": 500,
 			"data": "Get uploaded file failed",
@@ -61,7 +61,7 @@ func UploadFileForUPic(c *gin.Context) {
 
 	// Save uploaded files to data/uPic directory.
 	if err = c.SaveUploadedFile(file, "data/uPic/"+file.Filename); err != nil {
-		log.Errorf("Save file uploaded to uPic error: %+v", err)
+		slog.Error("save file uploaded to uPic error", slog.Any("error", err))
 		c.JSON(500, gin.H{
 			"code": 500,
 			"data": "Save uploaded file failed",
@@ -80,7 +80,7 @@ func UploadFileForUPic(c *gin.Context) {
 func RSS(c *gin.Context) {
 	rss, err := feed().ToRss()
 	if err != nil {
-		log.Errorf("Generate RSS content error: %+v", err)
+		slog.Error("generate RSS content error", slog.Any("error", err))
 		c.XML(500, "")
 		return
 	}
@@ -92,7 +92,7 @@ func RSS(c *gin.Context) {
 func Atom(c *gin.Context) {
 	rss, err := feed().ToAtom()
 	if err != nil {
-		log.Errorf("Generate atom content error: %+v", err)
+		slog.Error("generate Atom content error", slog.Any("error", err))
 		c.XML(500, "")
 		return
 	}
@@ -104,7 +104,7 @@ func Atom(c *gin.Context) {
 func Feed(c *gin.Context) {
 	rss, err := feed().ToJSON()
 	if err != nil {
-		log.Errorf("Generate feed content error: %+v", err)
+		slog.Error("generate feed content error", slog.Any("error", err))
 		c.JSON(500, "")
 		return
 	}
@@ -135,7 +135,7 @@ func feed() *feeds.Feed {
 func Mdcat(c *gin.Context) {
 	content, err := os.ReadFile("README.md")
 	if err != nil {
-		log.Errorf("Read README.md error: %+v", err)
+		slog.Error("read README.md error", slog.Any("error", err))
 		c.JSON(500, gin.H{
 			"code": 500,
 			"data": "Read README.md failed",
@@ -145,7 +145,7 @@ func Mdcat(c *gin.Context) {
 
 	html, err := markdown.ToHTML(content)
 	if err != nil {
-		log.Errorf("Convert markdown to HTML error: %+v", err)
+		slog.Error("convert markdown to HTML error", slog.Any("error", err))
 		c.JSON(500, gin.H{
 			"code": 500,
 			"data": "Convert markdown to HTML failed",

--- a/src/controller/user.go
+++ b/src/controller/user.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -10,7 +11,6 @@ import (
 	"github.com/Pengxn/go-xn/src/lib/cache"
 	"github.com/Pengxn/go-xn/src/lib/webauthn"
 	"github.com/Pengxn/go-xn/src/model"
-	"github.com/Pengxn/go-xn/src/util/log"
 )
 
 // RegisterPage returns register html page.
@@ -24,7 +24,7 @@ func BeginRegister(c *gin.Context) {
 	user := webauthn.NewUser(123, username)
 	creation, session, err := webauthn.BeginRegister(user)
 	if err != nil {
-		log.Errorf("BeginRegister error: %v", err)
+		slog.Error("BeginRegister error", slog.Any("error", err))
 
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"code":    http.StatusInternalServerError,
@@ -34,7 +34,7 @@ func BeginRegister(c *gin.Context) {
 	}
 
 	if err := cache.Add(username, session); err != nil {
-		log.Errorf("cache.Add error: %v", err)
+		slog.Error("cache.Add error", slog.Any("error", err))
 
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"code":    http.StatusInternalServerError,
@@ -59,7 +59,7 @@ type FinishRegisterRequest struct {
 func FinishRegister(c *gin.Context) {
 	data, err := c.GetRawData()
 	if err != nil {
-		log.Errorf("GetRawData error: %v", err)
+		slog.Error("GetRawData error", slog.Any("error", err))
 
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"code":    http.StatusInternalServerError,
@@ -84,7 +84,7 @@ func FinishRegister(c *gin.Context) {
 
 	credential, err := webauthn.FinishRegister(user, session.([]byte), creation.Credential)
 	if err != nil {
-		log.Errorf("FinishRegister error: %v", err)
+		slog.Error("FinishRegister error", slog.Any("error", err))
 
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"code":    http.StatusInternalServerError,
@@ -138,7 +138,7 @@ func BeginLogin(c *gin.Context) {
 		creation, session, err = beginLoginWithUsername(username)
 	}
 	if err != nil {
-		log.Errorf("BeginLogin error: %v", err)
+		slog.Error("BeginLogin error", slog.Any("error", err))
 
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"code":    http.StatusInternalServerError,
@@ -191,7 +191,7 @@ type FinishLoginRequest struct {
 func FinishLogin(c *gin.Context) {
 	data, err := c.GetRawData()
 	if err != nil {
-		log.Errorf("GetRawData error: %v", err)
+		slog.Error("GetRawData error", slog.Any("error", err))
 
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"code":    http.StatusInternalServerError,
@@ -211,7 +211,7 @@ func FinishLogin(c *gin.Context) {
 		_, err = webauthn.FinishDiscoverableLogin(nil, login.Session, login.Credential)
 	}
 	if err != nil {
-		log.Errorf("FinishLogin error: %v", err)
+		slog.Error("FinishLogin error", slog.Any("error", err))
 
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"code":    http.StatusInternalServerError,

--- a/src/controller/webdav.go
+++ b/src/controller/webdav.go
@@ -1,12 +1,11 @@
 package controller
 
 import (
+	"log/slog"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 	"golang.org/x/net/webdav"
-
-	"github.com/Pengxn/go-xn/src/util/log"
 )
 
 // WebdavMethods is a list of supported WebDAV methods.
@@ -22,7 +21,7 @@ func WebDAV(c *gin.Context) {
 		LockSystem: webdav.NewMemLS(),
 		Logger: func(r *http.Request, err error) {
 			if err != nil {
-				log.Errorf("[WebDAV] %s => %s error: %v", r.Method, r.URL.Path, err)
+				slog.Error("[WebDAV]", slog.String("method", r.Method), slog.String("path", r.URL.Path), slog.Any("error", err))
 			}
 		},
 	}

--- a/src/lib/mail/mail.go
+++ b/src/lib/mail/mail.go
@@ -5,11 +5,11 @@ import (
 	"crypto/tls"
 	"errors"
 	"html/template"
+	"log/slog"
 
 	"github.com/go-mail/mail/v2"
 
 	"github.com/Pengxn/go-xn/src/config"
-	"github.com/Pengxn/go-xn/src/util/log"
 	"github.com/Pengxn/go-xn/web"
 )
 
@@ -82,7 +82,7 @@ func MailContent(mailType MailType, magicLink string) (subject, content string) 
 		temp, err = template.New("mail").Parse(web.MailVerify)
 	}
 	if err != nil {
-		log.Errorf("Fail to parse mail template %d, error: %v", mailType, err)
+		slog.Error("Fail to parse mail template", slog.Any("error", err), slog.Any("mailType", mailType))
 		return "", content
 	}
 
@@ -97,7 +97,7 @@ func MailContent(mailType MailType, magicLink string) (subject, content string) 
 		"site":       site,
 		"magic_link": "https://magic-link.com/test?code=xxxx",
 	}); err != nil {
-		log.Errorf("Fail to execute mail template %d, error: %v", mailType, err)
+		slog.Error("Fail to execute mail template", slog.Any("error", err), slog.Any("mailType", mailType))
 		return "", content
 	}
 

--- a/src/lib/webauthn/webauthn.go
+++ b/src/lib/webauthn/webauthn.go
@@ -2,12 +2,12 @@ package webauthn
 
 import (
 	"encoding/json"
+	"log/slog"
 
 	"github.com/go-webauthn/webauthn/protocol"
 	"github.com/go-webauthn/webauthn/webauthn"
 
 	"github.com/Pengxn/go-xn/src/config"
-	"github.com/Pengxn/go-xn/src/util/log"
 )
 
 var w *webauthn.WebAuthn
@@ -20,7 +20,7 @@ func InitWebAuthn() {
 		RPDisplayName: config.RPDisplayName,
 		RPOrigins:     config.RPOrigins,
 	}); err != nil {
-		log.Errorln("New WebAuthn object error: ", err)
+		slog.Error("new WebAuthn object error", slog.Any("error", err))
 	}
 }
 

--- a/src/middleware/basic_auth.go
+++ b/src/middleware/basic_auth.go
@@ -1,12 +1,12 @@
 package middleware
 
 import (
+	"log/slog"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 
 	"github.com/Pengxn/go-xn/src/model"
-	"github.com/Pengxn/go-xn/src/util/log"
 )
 
 // BasicAuth is a middleware to check basic authentication.
@@ -26,7 +26,7 @@ func BasicAuth() gin.HandlerFunc {
 
 		has, user, err := model.GetUserByName(username)
 		if err != nil || !has {
-			log.Errorf("GetUserByName: %v", err)
+			slog.Error("GetUserByName", slog.Any("error", err))
 			c.String(http.StatusInternalServerError, "server error")
 			c.Abort()
 			return

--- a/src/middleware/logger.go
+++ b/src/middleware/logger.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"time"
@@ -10,7 +11,6 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/Pengxn/go-xn/src/config"
-	"github.com/Pengxn/go-xn/src/util/log"
 )
 
 // LoggerToFile is a custom logger middleware, it writes logs to os.Stdout and a file.
@@ -57,7 +57,7 @@ func writerLog() io.Writer {
 	// Logging to a file, append logging if the file already exists.
 	f, err := os.OpenFile(logFile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
 	if err != nil {
-		log.Errorf("open log file %s error: %v", logFile, err)
+		slog.Error("open log file error", slog.Any("error", err), slog.String("logFile", logFile))
 		return os.Stdout
 	}
 

--- a/src/middleware/sentry.go
+++ b/src/middleware/sentry.go
@@ -1,12 +1,13 @@
 package middleware
 
 import (
+	"log/slog"
+
 	"github.com/getsentry/sentry-go"
 	"github.com/getsentry/sentry-go/gin"
 	"github.com/gin-gonic/gin"
 
 	"github.com/Pengxn/go-xn/src/config"
-	"github.com/Pengxn/go-xn/src/util/log"
 )
 
 func Sentry() gin.HandlerFunc {
@@ -16,7 +17,7 @@ func Sentry() gin.HandlerFunc {
 		Dsn:   sentryConfig.DSN,
 		Debug: sentryConfig.Debug,
 	}); err != nil {
-		log.Errorf("Sentry initialization failed: %v", err)
+		slog.Error("Sentry initialization failed", slog.Any("error", err))
 	}
 
 	return sentrygin.New(sentrygin.Options{})

--- a/src/model/article.go
+++ b/src/model/article.go
@@ -1,9 +1,8 @@
 package model
 
 import (
+	"log/slog"
 	"time"
-
-	"github.com/Pengxn/go-xn/src/util/log"
 )
 
 // Article model
@@ -32,7 +31,7 @@ func ArticlesByPage(limit int, page int) []Article {
 		Desc("create_time").
 		Find(&articles)
 	if err != nil {
-		log.Errorf("ArticlesByPage throw error: %s", err)
+		slog.Error("ArticlesByPage throw error", slog.Any("error", err))
 	}
 
 	return articles
@@ -45,7 +44,7 @@ func AddArticle(article *Article) bool {
 
 	affected, err := db.InsertOne(article)
 	if err != nil {
-		log.Errorf("AddArticle throw error: %s", err)
+		slog.Error("AddArticle throw error", slog.Any("error", err))
 	}
 
 	return affected > 0
@@ -60,7 +59,7 @@ func ArticleExist(id uint64) bool {
 		ID: id,
 	})
 	if err != nil {
-		log.Errorf("ArticleExist throw error: %s", err)
+		slog.Error("ArticleExist throw error", slog.Any("error", err))
 	}
 
 	return has
@@ -75,7 +74,7 @@ func ArticlesCount() int {
 
 	count, err := db.Count(article)
 	if err != nil {
-		log.Errorf("ArticlesCount throw error: %s", err)
+		slog.Error("ArticlesCount throw error", slog.Any("error", err))
 	}
 
 	return int(count)
@@ -92,7 +91,7 @@ func ArticleByID(id uint64) (*Article, bool) {
 
 	has, err := db.Get(article)
 	if err != nil {
-		log.Errorf("ArticleByID throw error: %s", err)
+		slog.Error("ArticleByID throw error", slog.Any("error", err))
 	}
 
 	return article, has
@@ -109,7 +108,7 @@ func ArticleBySlug(slug string) (*Article, bool) {
 
 	has, err := db.Get(article)
 	if err != nil {
-		log.Errorf("ArticleBySlug throw error: %s", err)
+		slog.Error("ArticleBySlug throw error", slog.Any("error", err))
 	}
 
 	return article, has
@@ -122,7 +121,7 @@ func (a *Article) UpdateByID() bool {
 
 	affected, err := db.ID(a.ID).Update(a)
 	if err != nil {
-		log.Errorf("Article update throw error: %s", err)
+		slog.Error("Article update throw error", slog.Any("error", err))
 	}
 
 	return affected > 0

--- a/src/model/article_test.go
+++ b/src/model/article_test.go
@@ -1,10 +1,11 @@
 package model
 
 import (
+	"log"
+	"log/slog"
+
 	"github.com/go-ini/ini"
 	"xorm.io/xorm"
-
-	"github.com/Pengxn/go-xn/src/util/log"
 )
 
 func init() {
@@ -22,14 +23,14 @@ func init() {
 		&Article{ID: 8, Title: "Eight", Content: "8: Content Eight", Status: 1},
 		&Article{ID: 9, Title: "Nine", Content: "9: Content Nine", Status: 1},
 	); err != nil {
-		log.Infof("Init data to article table error: %+v, num: %d", err, num)
+		slog.Info("init data to article table", slog.Any("error", err), slog.Any("num", num))
 	}
 }
 
 var testORM = func() *xorm.Engine {
 	config, err := ini.LooseLoad("fyj.ini")
 	if err != nil {
-		log.Errorln("Fail to read fyj.ini file.", err)
+		slog.Error("fail to read fyj.ini file", slog.Any("error", err))
 	}
 
 	dbType := config.Section("test").Key("dbType").String()
@@ -51,10 +52,10 @@ var testORM = func() *xorm.Engine {
 func CleanTable(orm *xorm.Engine, modelTable any) {
 	if has, _ := orm.IsTableExist(modelTable); has {
 		if err := orm.DropTables(modelTable); err != nil {
-			log.Fatalf("Drop table error: %+v, model: %+v", err, modelTable)
+			log.Fatalf("drop table error: %+v, model: %+v", err, modelTable)
 		}
 	}
 	if err := orm.CreateTables(modelTable); err != nil {
-		log.Fatalf("Create table error: %+v, model: %+v", err, modelTable)
+		log.Fatalf("create table error: %+v, model: %+v", err, modelTable)
 	}
 }

--- a/src/model/init.go
+++ b/src/model/init.go
@@ -1,10 +1,11 @@
 package model
 
 import (
+	"log"
+
 	"xorm.io/xorm"
 
 	"github.com/Pengxn/go-xn/src/util/db"
-	"github.com/Pengxn/go-xn/src/util/log"
 )
 
 var orm *xorm.Engine = db.DBEngine()
@@ -18,12 +19,12 @@ func InitTables() {
 
 func initTable(bean any) {
 	if exist, err := orm.IsTableExist(bean); err != nil {
-		log.Panic("query table exist error: ", err)
+		log.Panicln("query table exist error", err)
 	} else if exist {
 		return
 	}
 
 	if err := orm.Sync(bean); err != nil {
-		log.Panic("create table error: ", err)
+		log.Panicln("create table error", err)
 	}
 }

--- a/src/model/option_test.go
+++ b/src/model/option_test.go
@@ -1,12 +1,11 @@
 package model
 
 import (
+	"log/slog"
 	"testing"
 
 	. "github.com/agiledragon/gomonkey/v2"
 	. "github.com/smartystreets/goconvey/convey"
-
-	"github.com/Pengxn/go-xn/src/util/log"
 )
 
 func init() {
@@ -20,7 +19,7 @@ func init() {
 		&Option{Name: "test_exist", Value: "1"},
 	)
 	if err != nil {
-		log.Infof("Init data to option table error: %+v, num: %d", err, num)
+		slog.Info("init data to option table error", slog.Any("error", err), slog.Any("num", num))
 	}
 }
 

--- a/src/model/webauthn.go
+++ b/src/model/webauthn.go
@@ -1,9 +1,8 @@
 package model
 
 import (
+	"log/slog"
 	"time"
-
-	"github.com/Pengxn/go-xn/src/util/log"
 )
 
 // WebAuthnCredential represents the WebAuthn credential data.
@@ -36,7 +35,7 @@ func (cred WebAuthnCredential) Add() bool {
 
 	affected, err := db.InsertOne(cred)
 	if err != nil {
-		log.Errorf("WebAuthn Credential add throw error: %+v, param: %+v", err, cred)
+		slog.Error("WebAuthn Credential add throw error", slog.Any("error", err), slog.Any("credential", cred))
 	}
 
 	return affected > 0
@@ -49,7 +48,7 @@ func (cred WebAuthnCredential) Get() []WebAuthnCredential {
 
 	var credList []WebAuthnCredential
 	if err := db.Find(&credList, &cred); err != nil {
-		log.Errorf("WebAuthn Credential get throw error: %+v, param: %+v", err, cred)
+		slog.Error("WebAuthn Credential get throw error", slog.Any("error", err), slog.Any("credential", cred))
 	}
 
 	return credList

--- a/src/route/static.go
+++ b/src/route/static.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"html/template"
 	"io/fs"
+	"log/slog"
 	"net/http"
 	"os"
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/Pengxn/go-xn/src/util/log"
 	"github.com/Pengxn/go-xn/web"
 )
 
@@ -49,7 +49,7 @@ func staticFile(g *gin.Engine, relativePath, filepath string, fsys ...http.FileS
 				return
 			}
 		}
-		log.Debugf("staticFile: %s not found", filepath)
+		slog.Debug("staticFile not found", slog.String("filepath", filepath))
 		c.String(http.StatusNotFound, "not found")
 	}
 	g.GET(relativePath, handler)
@@ -68,12 +68,12 @@ func staticFileFromFS(g *gin.Engine, relativePath, filepath string, fs http.File
 func templateFromFS(fsys fs.FS) *template.Template {
 	templates, err := fs.Sub(fsys, "templates")
 	if err != nil {
-		log.Errorf("HTML fs.Sub error: %+v", err)
+		slog.Error("HTML fs.Sub error", slog.Any("error", err))
 	}
 
 	t, err := template.ParseFS(templates, "*.html", "**/*.html")
 	if err != nil {
-		log.Errorf("HTML template.ParseFS error: %+v", err)
+		slog.Error("HTML template.ParseFS error", slog.Any("error", err))
 	}
 
 	if gin.IsDebugging() {
@@ -89,7 +89,7 @@ func templateFromFS(fsys fs.FS) *template.Template {
 func assetsFS() http.FileSystem {
 	assets, err := fs.Sub(web.EmbedFS, "assets")
 	if err != nil {
-		log.Errorf("FS fs.Sub error: %+v", err)
+		slog.Error("FS fs.Sub error", slog.Any("error", err))
 	}
 
 	return http.FS(assets)

--- a/src/util/db/db.go
+++ b/src/util/db/db.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"log"
 	"strings"
 
 	_ "github.com/go-sql-driver/mysql" // MySQL/MariaDB driver
@@ -9,7 +10,6 @@ import (
 	"xorm.io/xorm"
 
 	"github.com/Pengxn/go-xn/src/config"
-	"github.com/Pengxn/go-xn/src/util/log"
 )
 
 // getDBUrl returns database type and its DSN.
@@ -45,7 +45,7 @@ func getDBUrl() (dbType, dsn string) {
 func DBEngine() *xorm.Engine {
 	orm, err := xorm.NewEngine(getDBUrl())
 	if err != nil {
-		log.Fatalln("Can't connect your DB.", err)
+		log.Fatalln("can't connect your DB", err)
 	}
 
 	return orm


### PR DESCRIPTION
- Use standard `log/slog` package to replace custom `github.com/Pengxn/go-xn/src/util/log` package.
- Updated all logging function calls to match the `slog` APIs.
- Standardized log message formatting and capitalization and improved error logging with structured logging patterns.