### PR TITLE
Add doc comments about deprecated custom `log` package

### DIFF
--- a/src/util/log/log.go
+++ b/src/util/log/log.go
@@ -1,3 +1,11 @@
+// log package is a wrapper around the [logrus] logger.
+// It provides a simple interface for logging messages at different levels.
+// It also provides functions for logging messages with formatting options.
+//
+// Deprecated: this package is deprecated and will be removed in the next release.
+// Use the [log] and [log/slog] package instead for logging.
+//
+// [logrus]: https://github.com/sirupsen/logrus
 package log
 
 import (
@@ -16,94 +24,130 @@ func init() {
 }
 
 // Error logs a message at level Error.
+//
+// Deprecated: its recommended to use the [log/slog.Error] package instead.
 func Error(args ...any) {
 	logger.Error(args...)
 }
 
 // Errorf logs a message at level Error.
+//
+// Deprecated: its recommended to use the [log/slog.Error] or [log/slog.ErrorContext] instead.
 func Errorf(format string, args ...any) {
 	logger.Errorf(format, args...)
 }
 
 // Errorln logs a message at level Error.
+//
+// Deprecated: its recommended to use the [log/slog.Error] or [log/slog.ErrorContext] instead.
 func Errorln(format string, args ...any) {
 	logger.Errorln(args...)
 }
 
 // Info logs a message at level Info.
+//
+// Deprecated: its recommended to use the [log/slog.Info] or [log/slog.ErrorContext] instead.
 func Info(args ...any) {
 	logger.Info(args...)
 }
 
 // Infof logs a message at level Info.
+//
+// Deprecated: its recommended to use the [log/slog.Info] or [log/slog.InfoContext] instead.
 func Infof(format string, args ...any) {
 	logger.Infof(format, args...)
 }
 
 // Infoln logs a message at level Info.
+//
+// Deprecated: its recommended to use the [log/slog.Info] or [log/slog.InfoContext] instead.
 func Infoln(args ...any) {
 	logger.Infoln(args...)
 }
 
 // Debug logs a message at level Debug.
+//
+// Deprecated: its recommended to use the [log/slog.Debug] or [log/slog.DebugContext] instead.
 func Debug(args ...any) {
 	logger.Debug(args...)
 }
 
 // Debugf logs a message at level Debug.
+//
+// Deprecated: its recommended to use the [log/slog.Debug] or [log/slog.DebugContext] instead.
 func Debugf(format string, args ...any) {
 	logger.Debugf(format, args...)
 }
 
 // Debugln logs a message at level Debug.
+//
+// Deprecated: its recommended to use the [log/slog.Debug] or [log/slog.DebugContext] instead.
 func Debugln(args ...any) {
 	logger.Debugln(args...)
 }
 
 // Fatal logs a message at level Fatal and then
 // the process will exit with status set to 1.
+//
+// Deprecated: its recommended to use the [log.Fatal] instead.
 func Fatal(args ...any) {
 	logger.Fatal(args...)
 }
 
 // Fatalf logs a message at level Fatal and then
 // the process will exit with status set to 1.
+//
+// Deprecated: its recommended to use the [log.Fatalf] instead.
 func Fatalf(format string, args ...any) {
 	logger.Fatalf(format, args...)
 }
 
 // Fatalln logs a message at level Fatal and then
 // the process will exit with status set to 1.
+//
+// Deprecated: its recommended to use the [log.Fatalln] instead.
 func Fatalln(args ...any) {
 	logger.Fatalln(args...)
 }
 
 // Warn logs a message at level Warn.
+//
+// Deprecated: its recommended to use the [log/slog.Warn] or [log/slog.WarnContext] instead.
 func Warn(args ...any) {
 	logger.Warn(args...)
 }
 
 // Warnf logs a message at level Warn.
+//
+// Deprecated: its recommended to use the [log/slog.Warn] or [log/slog.WarnContext] instead.
 func Warnf(format string, args ...any) {
 	logger.Warnf(format, args...)
 }
 
 // Warnln logs a message at level Warn.
+//
+// Deprecated: its recommended to use the [log/slog.Warn] or [log/slog.WarnContext] instead.
 func Warnln(args ...any) {
 	logger.Warnln(args...)
 }
 
 // Panic logs a message at level Panic.
+//
+// Deprecated: its recommended to use the [log.Panic] instead.
 func Panic(args ...any) {
 	logger.Panic(args...)
 }
 
 // Panicf logs a message at level Panic.
+//
+// Deprecated: its recommended to use the [log.Panicf] instead.
 func Panicf(format string, args ...any) {
 	logger.Panicf(format, args...)
 }
 
 // Panicln logs a message at level Panic.
+//
+// Deprecated: its recommended to use the [log.Panicln] instead.
 func Panicln(format string, args ...any) {
 	logger.Panicln(args...)
 }

--- a/src/util/log/log.go
+++ b/src/util/log/log.go
@@ -25,63 +25,63 @@ func init() {
 
 // Error logs a message at level Error.
 //
-// Deprecated: its recommended to use the [log/slog.Error] package instead.
+// Deprecated: it's recommended to use the [log/slog.Error] or [log/slog.ErrorContext] package instead.
 func Error(args ...any) {
 	logger.Error(args...)
 }
 
 // Errorf logs a message at level Error.
 //
-// Deprecated: its recommended to use the [log/slog.Error] or [log/slog.ErrorContext] instead.
+// Deprecated: it's recommended to use the [log/slog.Error] or [log/slog.ErrorContext] instead.
 func Errorf(format string, args ...any) {
 	logger.Errorf(format, args...)
 }
 
 // Errorln logs a message at level Error.
 //
-// Deprecated: its recommended to use the [log/slog.Error] or [log/slog.ErrorContext] instead.
+// Deprecated: it's recommended to use the [log/slog.Error] or [log/slog.ErrorContext] instead.
 func Errorln(format string, args ...any) {
 	logger.Errorln(args...)
 }
 
 // Info logs a message at level Info.
 //
-// Deprecated: its recommended to use the [log/slog.Info] or [log/slog.ErrorContext] instead.
+// Deprecated: it's recommended to use the [log/slog.Info] or [log/slog.InfoContext] instead.
 func Info(args ...any) {
 	logger.Info(args...)
 }
 
 // Infof logs a message at level Info.
 //
-// Deprecated: its recommended to use the [log/slog.Info] or [log/slog.InfoContext] instead.
+// Deprecated: it's recommended to use the [log/slog.Info] or [log/slog.InfoContext] instead.
 func Infof(format string, args ...any) {
 	logger.Infof(format, args...)
 }
 
 // Infoln logs a message at level Info.
 //
-// Deprecated: its recommended to use the [log/slog.Info] or [log/slog.InfoContext] instead.
+// Deprecated: it's recommended to use the [log/slog.Info] or [log/slog.InfoContext] instead.
 func Infoln(args ...any) {
 	logger.Infoln(args...)
 }
 
 // Debug logs a message at level Debug.
 //
-// Deprecated: its recommended to use the [log/slog.Debug] or [log/slog.DebugContext] instead.
+// Deprecated: it's recommended to use the [log/slog.Debug] or [log/slog.DebugContext] instead.
 func Debug(args ...any) {
 	logger.Debug(args...)
 }
 
 // Debugf logs a message at level Debug.
 //
-// Deprecated: its recommended to use the [log/slog.Debug] or [log/slog.DebugContext] instead.
+// Deprecated: it's recommended to use the [log/slog.Debug] or [log/slog.DebugContext] instead.
 func Debugf(format string, args ...any) {
 	logger.Debugf(format, args...)
 }
 
 // Debugln logs a message at level Debug.
 //
-// Deprecated: its recommended to use the [log/slog.Debug] or [log/slog.DebugContext] instead.
+// Deprecated: it's recommended to use the [log/slog.Debug] or [log/slog.DebugContext] instead.
 func Debugln(args ...any) {
 	logger.Debugln(args...)
 }
@@ -89,7 +89,7 @@ func Debugln(args ...any) {
 // Fatal logs a message at level Fatal and then
 // the process will exit with status set to 1.
 //
-// Deprecated: its recommended to use the [log.Fatal] instead.
+// Deprecated: it's recommended to use the [log.Fatal] instead.
 func Fatal(args ...any) {
 	logger.Fatal(args...)
 }
@@ -97,7 +97,7 @@ func Fatal(args ...any) {
 // Fatalf logs a message at level Fatal and then
 // the process will exit with status set to 1.
 //
-// Deprecated: its recommended to use the [log.Fatalf] instead.
+// Deprecated: it's recommended to use the [log.Fatalf] instead.
 func Fatalf(format string, args ...any) {
 	logger.Fatalf(format, args...)
 }
@@ -105,49 +105,49 @@ func Fatalf(format string, args ...any) {
 // Fatalln logs a message at level Fatal and then
 // the process will exit with status set to 1.
 //
-// Deprecated: its recommended to use the [log.Fatalln] instead.
+// Deprecated: it's recommended to use the [log.Fatalln] instead.
 func Fatalln(args ...any) {
 	logger.Fatalln(args...)
 }
 
 // Warn logs a message at level Warn.
 //
-// Deprecated: its recommended to use the [log/slog.Warn] or [log/slog.WarnContext] instead.
+// Deprecated: it's recommended to use the [log/slog.Warn] or [log/slog.WarnContext] instead.
 func Warn(args ...any) {
 	logger.Warn(args...)
 }
 
 // Warnf logs a message at level Warn.
 //
-// Deprecated: its recommended to use the [log/slog.Warn] or [log/slog.WarnContext] instead.
+// Deprecated: it's recommended to use the [log/slog.Warn] or [log/slog.WarnContext] instead.
 func Warnf(format string, args ...any) {
 	logger.Warnf(format, args...)
 }
 
 // Warnln logs a message at level Warn.
 //
-// Deprecated: its recommended to use the [log/slog.Warn] or [log/slog.WarnContext] instead.
+// Deprecated: it's recommended to use the [log/slog.Warn] or [log/slog.WarnContext] instead.
 func Warnln(args ...any) {
 	logger.Warnln(args...)
 }
 
 // Panic logs a message at level Panic.
 //
-// Deprecated: its recommended to use the [log.Panic] instead.
+// Deprecated: it's recommended to use the [log.Panic] instead.
 func Panic(args ...any) {
 	logger.Panic(args...)
 }
 
 // Panicf logs a message at level Panic.
 //
-// Deprecated: its recommended to use the [log.Panicf] instead.
+// Deprecated: it's recommended to use the [log.Panicf] instead.
 func Panicf(format string, args ...any) {
 	logger.Panicf(format, args...)
 }
 
 // Panicln logs a message at level Panic.
 //
-// Deprecated: its recommended to use the [log.Panicln] instead.
+// Deprecated: it's recommended to use the [log.Panicln] instead.
 func Panicln(format string, args ...any) {
 	logger.Panicln(args...)
 }

--- a/src/util/log/slog/slog.go
+++ b/src/util/log/slog/slog.go
@@ -10,7 +10,7 @@ import (
 	"github.com/Pengxn/go-xn/src/config"
 )
 
-// override default logger with `tint` logger.
+// override default logger with `tint` logger, default to [DEBUG] level.
 func init() {
 	logger := slog.New(tint.NewHandler(os.Stderr, &tint.Options{
 		Level:      slog.LevelDebug,
@@ -22,6 +22,9 @@ func init() {
 }
 
 // SetLogger sets the logger with the given config settings.
+// The default logger is [tint] logger with colorized output.
+//
+// [tint]: https://github.com/lmittmann/tint
 func SetLogger(c config.LoggerConfig) {
 	if c.APP == "" {
 		return
@@ -34,7 +37,7 @@ func SetLogger(c config.LoggerConfig) {
 	slog.SetDefault(logger)
 }
 
-// mapToLevel maps string level to slog.Level.
+// mapToLevel maps string level to [log/slog.Level].
 // If the level is not valid, default to 'INFO'.
 func mapToLevel(level string) slog.Level {
 	switch strings.ToUpper(level) {


### PR DESCRIPTION
- Add comprehensive deprecation notices to the `github.com/Pengxn/go-xn/src/util/log` package, which wraps the third-party `logrus` library.
- Each function is now marked with a `Deprecated` comment that directs users to the equivalent standard library alternatives in `log` and `log/slog`.
- Also warn users about the deprecation statement in the doc comments of the `github.com/Pengxn/go-xn/src/util/log` package.

related issue #427 