### PR TITLE
ci: disable `fetch-depth` setting in checkout action

### DIFF
--- a/.github/workflows/test.docker.yml
+++ b/.github/workflows/test.docker.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Fetche Latest Image
         run: |

--- a/.github/workflows/test.linux.yml
+++ b/.github/workflows/test.linux.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install Go
         uses: actions/setup-go@v5

--- a/.github/workflows/test.macos.yml
+++ b/.github/workflows/test.macos.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install Go
         uses: actions/setup-go@v5

--- a/.github/workflows/test.windows.yml
+++ b/.github/workflows/test.windows.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
Add `fetch-depth: 0` parameter to checkout actions for all workflows to ensure the repository's entire history (especially **tags**) is fetched.
The **tags** information is required for the `git describe` command to work correctly in the build process, which is used to generate the version string for the binary, refer to `Makefile` file for more details.

other references: commit f3fda145599e703f541da4d928ed2845a24a6d91