### PR TITLE
Deprecate logrus hooks in `hook` package

### DIFF
--- a/src/util/log/hook/bark.go
+++ b/src/util/log/hook/bark.go
@@ -1,3 +1,11 @@
+// Package hook provides a [logrus] hook for sending logs to [Bark], [Telegram Bot] and [io.Writer].
+//
+// Deprecated: this package is deprecated and will be removed in the next release.
+// Use [github.com/Pengxn/go-xn/src/util/log] instead.
+//
+// [logrus]: https://github.com/sirupsen/logrus
+// [Bark]: https://github.com/Finb/Bark
+// [Telegram Bot]: https://core.telegram.org/bots/api
 package hook
 
 import (
@@ -21,6 +29,11 @@ type BarkHook struct {
 }
 
 // NewBarkHook creates new BarkHook instance with given token.
+//
+// Deprecated: this function is deprecated and will be removed in the next release.
+// refer to [#429]
+//
+// [#429]: https://github.com/Pengxn/go-xn/pull/429
 func NewBarkHook(token string) *BarkHook {
 	return &BarkHook{
 		token:   token,

--- a/src/util/log/hook/io_write.go
+++ b/src/util/log/hook/io_write.go
@@ -19,6 +19,11 @@ type writerHook struct {
 
 // NewWriterHook returns a new writerHook,
 // which will write logs to the given io.Writer.
+//
+// Deprecated: this function is deprecated and will be removed in the next release.
+// refer to [#429]
+//
+// [#429]: https://github.com/Pengxn/go-xn/pull/429
 func NewWriterHook(output io.Writer) *writerHook {
 	return &writerHook{
 		output: output,

--- a/src/util/log/hook/telegram.go
+++ b/src/util/log/hook/telegram.go
@@ -23,6 +23,11 @@ type TelegramHook struct {
 }
 
 // NewTelegramHook creates new hook instance with given token.
+//
+// Deprecated: this function is deprecated and will be removed in the next release.
+// refer to [#429]
+//
+// [#429]: https://github.com/Pengxn/go-xn/pull/429
 func NewTelegramHook(token string) *TelegramHook {
 	return &TelegramHook{
 		token:   token,


### PR DESCRIPTION
- Mark all hook implementations in the `github.com/Pengxn/go-xn/src/util/log/hook` package as deprecated, including Bark, io.Writer and Telegram Bot hooks.
- Add proper doc comments with deprecation notices to inform users that it will be removed in the next release.

refer to pull request #429 and issue #427