### PR TITLE
Refactor method signature to return only error

### DIFF
--- a/src/util/slog/bark_write.go
+++ b/src/util/slog/bark_write.go
@@ -41,11 +41,11 @@ func (bw *BarkWriter) Write(msg []byte) (n int, err error) {
 		return
 	}
 
-	n, err = bw.send(raw)
-	if err != nil {
+	if err = bw.send(raw); err != nil {
 		fmt.Fprintf(os.Stderr, "[bark] log error: %v, msg: %s", err, msg)
 	}
 
+	n = len(msg)
 	return
 }
 
@@ -53,7 +53,7 @@ func (bw *BarkWriter) Write(msg []byte) (n int, err error) {
 // It is called by the [Write] method.
 //
 // [API]: https://bark.day.app/#/tutorial
-func (bw *BarkWriter) send(msg []byte) (n int, err error) {
+func (bw *BarkWriter) send(msg []byte) (err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), bw.timeout)
 	defer cancel()
 
@@ -73,10 +73,10 @@ func (bw *BarkWriter) send(msg []byte) (n int, err error) {
 		return
 	}
 	if response.StatusCode != http.StatusOK {
-		return 0, fmt.Errorf("response status code is %d, data: %s", response.StatusCode, body)
+		return fmt.Errorf("response status code is %d, data: %s", response.StatusCode, body)
 	}
 
-	return len(msg), nil
+	return nil
 }
 
 // barkMessage is the message format for Bark.

--- a/src/util/slog/newrelic.go
+++ b/src/util/slog/newrelic.go
@@ -37,19 +37,18 @@ func (nr *NewRelicWriter) Write(msg []byte) (n int, err error) {
 
 	// TODO: concurrent write by goroutine
 
-	n, err = nr.send(msg)
-	if err != nil {
+	if err = nr.send(msg); err != nil {
 		fmt.Fprintf(os.Stderr, "[newrelic] log error: %v, msg: %s", err, msg)
 	}
 
-	return
+	return len(msg), nil
 }
 
 // send sends the log message to NewRelic using its [Log HTTP API].
 // It is called by the [Write] method.
 //
 // [Log HTTP API]: https://docs.newrelic.com/docs/logs/log-api/introduction-log-api/#endpoint
-func (nr *NewRelicWriter) send(msg []byte) (n int, err error) {
+func (nr *NewRelicWriter) send(msg []byte) (err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), nr.timeout)
 	defer cancel()
 
@@ -70,8 +69,8 @@ func (nr *NewRelicWriter) send(msg []byte) (n int, err error) {
 		return
 	}
 	if response.StatusCode != http.StatusAccepted {
-		return 0, fmt.Errorf("response status code is %d, data: %s", response.StatusCode, body)
+		return fmt.Errorf("response status code is %d, data: %s", response.StatusCode, body)
 	}
 
-	return len(msg), nil
+	return nil
 }

--- a/src/util/slog/telegram_writer.go
+++ b/src/util/slog/telegram_writer.go
@@ -49,6 +49,7 @@ func (th *TelegramWriter) Write(msg []byte) (n int, err error) {
 		fmt.Fprintf(os.Stderr, "[Telegram] log error: %v, msg: %s", err, msg)
 	}
 
+	n = len(msg)
 	return
 }
 


### PR DESCRIPTION
- Remove unnecessary return argument from the `send` method.
  The `n` variable in the `send` method was originally intended to represent the number of bytes sent,
  but it was not being handled in the `send` method itself.
- Return actual message length in `Write` method as per [io.Writer] interface requirements
- Fix error handling flow in `Write` methods.

[io.Writer]: https://pkg.go.dev/io@go1.24.2#Writer