### PR TITLE
Migrate github.com/urfave/cli to v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/rs/cors v1.11.1
 	github.com/schollz/progressbar/v3 v3.18.0
 	github.com/smartystreets/goconvey v1.8.1
-	github.com/urfave/cli/v2 v2.27.6
+	github.com/urfave/cli/v3 v3.1.1
 	github.com/yuin/goldmark v1.7.8
 	golang.org/x/crypto v0.37.0
 	golang.org/x/net v0.39.0
@@ -47,7 +47,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.4 // indirect
 	github.com/cloudwego/iasm v0.2.0 // indirect
-	github.com/cpuguy83/go-md2man/v2 v2.0.5 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/fxamacker/cbor/v2 v2.8.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
@@ -72,13 +71,11 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
-	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/smarty/assertions v1.15.0 // indirect
 	github.com/syndtr/goleveldb v1.0.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
-	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
 	golang.org/x/arch v0.8.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect
 	golang.org/x/term v0.31.0 // indirect

--- a/src/cmd/agent.go
+++ b/src/cmd/agent.go
@@ -1,11 +1,12 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net"
 
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 	"google.golang.org/grpc"
 
 	"github.com/Pengxn/go-xn/src/rpc"
@@ -21,7 +22,7 @@ var (
 		Description: `Run a gRPC serveras an agent side, it only support gRPC protocol.`,
 		Flags:       []cli.Flag{agentPort},
 		Action:      runGRPCServer,
-		Subcommands: []*cli.Command{agentPingCmd},
+		Commands:    []*cli.Command{agentPingCmd},
 	}
 	agentPingCmd = &cli.Command{
 		Name:        "ping",
@@ -46,7 +47,7 @@ var (
 	}
 )
 
-func runGRPCServer(c *cli.Context) error {
+func runGRPCServer(ctx context.Context, c *cli.Command) error {
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", c.Int("port")))
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
@@ -65,7 +66,7 @@ func runGRPCServer(c *cli.Context) error {
 	return nil
 }
 
-func pingAgent(c *cli.Context) error {
+func pingAgent(ctx context.Context, c *cli.Command) error {
 	pong, err := rpc.Client(c.String("url"))
 	if err != nil {
 		log.Fatalln("failed to ping agent:", err)

--- a/src/cmd/cmd.go
+++ b/src/cmd/cmd.go
@@ -1,14 +1,15 @@
 package cmd
 
 import (
+	"context"
 	"os"
 
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 )
 
 // Execute to run cmd
 func Execute() error {
-	app := &cli.App{
+	app := &cli.Command{
 		Name:    "go-xn",
 		Usage:   "The platform for publishing and running your blog",
 		Version: version,
@@ -20,5 +21,5 @@ func Execute() error {
 		},
 	}
 
-	return app.Run(os.Args)
+	return app.Run(context.Background(), os.Args)
 }

--- a/src/cmd/update.go
+++ b/src/cmd/update.go
@@ -3,12 +3,13 @@ package cmd
 import (
 	"archive/zip"
 	"bytes"
+	"context"
 	"io"
 	"os"
 	"path/filepath"
 
 	"github.com/schollz/progressbar/v3"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 
 	"github.com/Pengxn/go-xn/src/lib/github"
 	"github.com/Pengxn/go-xn/src/util/httplib"
@@ -26,14 +27,13 @@ var (
 
 	// nightlyFlag is a flag to specify updating to the latest nightly build.
 	nightlyFlag = &cli.BoolFlag{
-		Name:               "nightly",
-		Aliases:            []string{"n"},
-		Usage:              "Update to the latest nightly build",
-		DisableDefaultText: true,
+		Name:    "nightly",
+		Aliases: []string{"n"},
+		Usage:   "Update to the latest nightly build",
 	}
 )
 
-func update(c *cli.Context) error {
+func update(ctx context.Context, c *cli.Command) error {
 	var (
 		link string
 		err  error

--- a/src/cmd/version.go
+++ b/src/cmd/version.go
@@ -1,10 +1,11 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"runtime"
 
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 )
 
 // Version information for cmd
@@ -27,7 +28,7 @@ And it display revision and built time information.`,
 )
 
 // showVersion prints the version information to stdout
-func showVersion(c *cli.Context) error {
+func showVersion(ctx context.Context, c *cli.Command) error {
 	fmt.Printf(`FYJ %s
 ---------------------------------
 - Go version: %s

--- a/src/cmd/web.go
+++ b/src/cmd/web.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
+	"context"
 	"log"
 
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 
 	"github.com/Pengxn/go-xn/src/config"
 	"github.com/Pengxn/go-xn/src/lib/webauthn"
@@ -26,7 +27,7 @@ If '--port' flag is not used, it will use port 7991 by default.`,
 		},
 	}
 
-	configFile = &cli.PathFlag{
+	configFile = &cli.StringFlag{
 		Name:        "config",
 		Aliases:     []string{"c"},
 		Usage:       "Custom configuration file path",
@@ -40,18 +41,17 @@ If '--port' flag is not used, it will use port 7991 by default.`,
 		Value:   7991,
 	}
 	debug = &cli.BoolFlag{
-		Name:               "debug",
-		Aliases:            []string{"d"},
-		Usage:              "Enable debug mode, print extra debugging information",
-		DisableDefaultText: true,
+		Name:    "debug",
+		Aliases: []string{"d"},
+		Usage:   "Enable debug mode, print extra debugging information",
 	}
 )
 
 // runWeb is the entry point to the web server.
 // Parses the arguments, routes and others.
-func runWeb(c *cli.Context) error {
+func runWeb(ctx context.Context, c *cli.Command) error {
 	// Override config by cli flag
-	config.OverrideConfigByFlag(c)
+	config.OverrideConfigByFlag(ctx, c)
 	model.InitTables()
 	webauthn.InitWebAuthn()
 

--- a/src/config/cmd.go
+++ b/src/config/cmd.go
@@ -1,17 +1,18 @@
 package config
 
 import (
+	"context"
 	"log/slog"
 	"os"
 
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 
 	"github.com/Pengxn/go-xn/src/util/file"
 )
 
-func OverrideConfigByFlag(c *cli.Context) {
+func OverrideConfigByFlag(ctx context.Context, c *cli.Command) {
 	if c.IsSet("config") { // specified config file
-		f := c.Path("config")
+		f := c.String("config")
 		if !file.IsExist(f) || !file.IsFile(f) {
 			slog.Error("specified config file not found", slog.String("filename", f))
 		}


### PR DESCRIPTION
- Migrate `github.com/urfave/cli` from v2 to v3, and update `go.mod` file accordingly.
- Update flag types and command structure to match `v3` changes:
  * PathFlag to StringFlag (including access methods Path to String), as the `PathFlag` is removed in v3.
  * Subcommands to Commands field.
  * Replace cli.App with cli.Command, `App` is removed in v3.
  * Update function signatures to accept `context.Context` parameter.
  * Update `Action` function signatures to accept `context.Context` and `*cli.Command` instead of `*cli.Context`.
  * … ,  refer to [Migration Guide: v2 to v3](https://cli.urfave.org/migrate-v2-to-v3/)
- Remove `DisableDefaultText` settings for `BoolFlag`, as it is no longer displayed by default in v3.