### PR TITLE
Add log config to support multiple log writers

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -87,9 +87,12 @@ type SentryConfig struct {
 
 // LoggerConfig is configuration for logger.
 type LoggerConfig struct {
-	Level string `ini:"level"`
-	APP   string `ini:"app"`
-	Route string `ini:"route"`
+	Level    string `ini:"level"`
+	Route    string `ini:"route"`
+	APP      string `ini:"app"`      // log writer: bark, telegram, newrelic, default: os.Stdout
+	Bark     string `ini:"bark"`     // bark token
+	Telegram string `ini:"telegram"` // telegram bot token
+	Newrelic string `ini:"newrelic"` // newrelic api key
 }
 
 // WebAuthnConfig is the WebAuthn configuration.

--- a/src/config/example.ini
+++ b/src/config/example.ini
@@ -30,9 +30,9 @@ DSN   = https://xxx@sentry.io/xxx # sentry DSN
 debug = false                     # enable sentry debug (default: false)
 
 [log]
-level = INFO      # log level: DEBUG, INFO, WARN, ERROR (default: INFO)
-app   = app.log   # log path for server                 (default: app.log)
-route = route.log # log path for route request          (default use stdout if empty)
+level = INFO      # log level: DEBUG, INFO, WARN, ERROR  (default: INFO)
+route = route.log # log path for route request           (default use stdout if empty)
+app   = os.Stdout # log writer: bark, telegram, newrelic (default: os.Stdout)
 
 [webauthn]
 rpID          = example.com

--- a/src/util/slog/slog.go
+++ b/src/util/slog/slog.go
@@ -2,6 +2,7 @@ package slogger
 
 import (
 	"context"
+	"io"
 	"log/slog"
 	"os"
 	"runtime"
@@ -39,7 +40,7 @@ func SetLogger(ctx context.Context, c config.LoggerConfig) {
 		return
 	}
 
-	logger := slog.New(slog.NewJSONHandler(os.Stdout,
+	logger := slog.New(slog.NewJSONHandler(useWriter(c),
 		&slog.HandlerOptions{
 			Level: mapToLevel(c.Level),
 		})).WithGroup("app").
@@ -53,6 +54,23 @@ func SetLogger(ctx context.Context, c config.LoggerConfig) {
 	}
 
 	slog.SetDefault(logger)
+}
+
+func useWriter(c config.LoggerConfig) io.Writer {
+	switch c.APP {
+	case "bark": // bark
+		slog.Debug("use log writer: bark")
+		return NewBark(c.Bark)
+	case "telegram": // telegram
+		slog.Debug("use log writer: telegram")
+		return NewTelegram(c.Telegram)
+	case "newrelic": // newrelic
+		slog.Debug("use log writer: newrelic")
+		return NewRelic(c.Newrelic)
+	default:
+		slog.Debug("use default log writer: os.Stdout")
+		return os.Stdout
+	}
 }
 
 // mapToLevel maps string level to [log/slog.Level].


### PR DESCRIPTION
- Extend `LoggerConfig` struct to include config for Bark, Telegram and NewRelic writers.
- Update `example.ini` config file to include new log writer options.
- Create `useWriter()` function to select and instantiate the appropriate log writer based on the `APP` field in the config, defaulting to `os.Stdout` if no valid writer is specified, and log messages indicating which writer is being used.