### PR TITLE
Add OpenTelemetry integration for distributed tracing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,11 @@ require (
 	github.com/smartystreets/goconvey v1.8.1
 	github.com/urfave/cli/v3 v3.1.1
 	github.com/yuin/goldmark v1.7.10
+	go.opentelemetry.io/otel v1.35.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.35.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.35.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.35.0
+	go.opentelemetry.io/otel/sdk v1.35.0
 	golang.org/x/crypto v0.37.0
 	golang.org/x/net v0.39.0
 	google.golang.org/grpc v1.71.1
@@ -42,45 +47,53 @@ tool (
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc // indirect
-	github.com/bytedance/sonic v1.11.6 // indirect
-	github.com/bytedance/sonic/loader v0.1.1 // indirect
+	github.com/bytedance/sonic v1.12.10 // indirect
+	github.com/bytedance/sonic/loader v0.2.3 // indirect
+	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/cloudwego/base64x v0.1.4 // indirect
-	github.com/cloudwego/iasm v0.2.0 // indirect
+	github.com/cloudwego/base64x v0.1.5 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/fxamacker/cbor/v2 v2.8.0 // indirect
-	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
-	github.com/gin-contrib/sse v0.1.0 // indirect
+	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
+	github.com/gin-contrib/sse v1.0.0 // indirect
+	github.com/go-logr/logr v1.4.2 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/go-playground/validator/v10 v10.20.0 // indirect
+	github.com/go-playground/validator/v10 v10.25.0 // indirect
 	github.com/go-webauthn/x v0.1.20 // indirect
-	github.com/goccy/go-json v0.10.2 // indirect
+	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/go-tpm v0.9.3 // indirect
 	github.com/gopherjs/gopherjs v1.17.2 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.1 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
-	github.com/klauspost/cpuid/v2 v2.2.7 // indirect
+	github.com/klauspost/cpuid/v2 v2.2.10 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
+	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/smarty/assertions v1.15.0 // indirect
 	github.com/syndtr/goleveldb v1.0.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
-	golang.org/x/arch v0.8.0 // indirect
+	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
+	go.opentelemetry.io/otel/metric v1.35.0 // indirect
+	go.opentelemetry.io/otel/trace v1.35.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
+	golang.org/x/arch v0.14.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect
 	golang.org/x/term v0.31.0 // indirect
 	golang.org/x/text v0.24.0 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20250115164207-1a7da9e5054f // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20250218202821-56aae31c358a // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20250218202821-56aae31c358a // indirect
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.5.1 // indirect
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
 	gopkg.in/mail.v2 v2.3.1 // indirect

--- a/src/util/otel/otel.go
+++ b/src/util/otel/otel.go
@@ -1,0 +1,82 @@
+package otel
+
+import (
+	"context"
+	"log"
+	"log/slog"
+	"runtime"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/sdk/resource"
+	"go.opentelemetry.io/otel/sdk/trace"
+)
+
+func InitTrace(ctx context.Context, c Config) func(context.Context) error {
+	var client otlptrace.Client
+	switch c.ClientType {
+	case "grpc":
+		slog.Debug("init grpc otel client")
+		client = newGRPCClient(c.Endpoint, c.Headers)
+	case "http":
+		slog.Debug("init https otel client")
+		client = newHTTPClient(c.Endpoint, c.Headers)
+	default:
+		slog.Warn("unknown otel client", slog.String("client", c.ClientType))
+	}
+
+	return initOTELTracer(ctx, client)
+}
+
+type Config struct {
+	ClientType string
+	Endpoint   string
+	Headers    map[string]string
+}
+
+func newGRPCClient(endpoint string, headers map[string]string) otlptrace.Client {
+	return otlptracegrpc.NewClient(
+		otlptracegrpc.WithEndpoint(endpoint),
+		otlptracegrpc.WithHeaders(headers),
+	)
+}
+
+func newHTTPClient(endpoint string, headers map[string]string) otlptrace.Client {
+	return otlptracehttp.NewClient(
+		otlptracehttp.WithEndpoint(endpoint),
+		otlptracehttp.WithHeaders(headers),
+	)
+}
+
+func initOTELTracer(ctx context.Context, client otlptrace.Client) func(context.Context) error {
+	exporter, err := otlptrace.New(ctx, client)
+	if err != nil {
+		log.Fatalf("failed to create exporter: %s", err)
+	}
+
+	resources, err := resource.New(
+		context.Background(),
+		resource.WithAttributes(
+			attribute.String("service.name", "go-xn"),
+			attribute.String("service.os", runtime.GOOS),
+			attribute.String("service.arch", runtime.GOARCH),
+		),
+	)
+	if err != nil {
+		log.Fatalf("failed to set resources: %s", err)
+	}
+
+	otel.SetTracerProvider(
+		trace.NewTracerProvider(
+			trace.WithSampler(trace.AlwaysSample()),
+			trace.WithSpanProcessor(trace.NewBatchSpanProcessor(exporter)),
+			trace.WithSyncer(exporter),
+			trace.WithResource(resources),
+		),
+	)
+
+	return exporter.Shutdown
+}

--- a/src/util/otel/otel.go
+++ b/src/util/otel/otel.go
@@ -28,6 +28,8 @@ func InitTrace(ctx context.Context, c Config) func(context.Context) error {
 		client = newHTTPClient(c.Endpoint, c.Headers)
 	default:
 		slog.Warn("unknown otel client", slog.String("client", c.ClientType))
+		slog.Debug("init otel client with default grpc")
+		client = newGRPCClient(c.Endpoint, c.Headers)
 	}
 
 	return initOTELTracer(ctx, client)
@@ -74,8 +76,7 @@ func initOTELTracer(ctx context.Context, client otlptrace.Client) func(context.C
 	}
 
 	// create the resource
-	resources, err := resource.New(
-		context.Background(),
+	resources, err := resource.New(ctx,
 		resource.WithAttributes(
 			attribute.String("service.name", "go-xn"),
 			attribute.String("service.os", runtime.GOOS),

--- a/src/util/otel/otel.go
+++ b/src/util/otel/otel.go
@@ -15,6 +15,8 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace"
 )
 
+// InitTrace initializes the OpenTelemetry trace exporter with the given config.
+// It returns a function to shut down the exporter when done.
 func InitTrace(ctx context.Context, c Config) func(context.Context) error {
 	var client otlptrace.Client
 	switch c.ClientType {
@@ -31,12 +33,22 @@ func InitTrace(ctx context.Context, c Config) func(context.Context) error {
 	return initOTELTracer(ctx, client)
 }
 
+// Config is the configuration for [OpenTelemetry].
+// It contains the client type, endpoint, and headers for the exporter.
+// The client type can be either "grpc" or "http".
+// The endpoint is the URL of the [OpenTelemetry Collector], default not including `v1/trace`.
+// refer to https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/
+//
+// [OpenTelemetry]: https://opentelemetry.io/
+// [OpenTelemetry Collector]: https://opentelemetry.io/docs/collector/
 type Config struct {
 	ClientType string
 	Endpoint   string
 	Headers    map[string]string
 }
 
+// newGRPCClient creates a new gRPC client for OpenTelemetry.
+// https://opentelemetry.io/docs/languages/go/exporters/#otlp-traces-over-http
 func newGRPCClient(endpoint string, headers map[string]string) otlptrace.Client {
 	return otlptracegrpc.NewClient(
 		otlptracegrpc.WithEndpoint(endpoint),
@@ -44,6 +56,8 @@ func newGRPCClient(endpoint string, headers map[string]string) otlptrace.Client 
 	)
 }
 
+// newHTTPClient creates a new HTTP client for OpenTelemetry.
+// https://opentelemetry.io/docs/languages/go/exporters/#otlp-traces-over-http
 func newHTTPClient(endpoint string, headers map[string]string) otlptrace.Client {
 	return otlptracehttp.NewClient(
 		otlptracehttp.WithEndpoint(endpoint),
@@ -51,12 +65,15 @@ func newHTTPClient(endpoint string, headers map[string]string) otlptrace.Client 
 	)
 }
 
+// initOTELTracer initializes the OpenTelemetry tracer with the given client.
 func initOTELTracer(ctx context.Context, client otlptrace.Client) func(context.Context) error {
+	// create the exporter
 	exporter, err := otlptrace.New(ctx, client)
 	if err != nil {
 		log.Fatalf("failed to create exporter: %s", err)
 	}
 
+	// create the resource
 	resources, err := resource.New(
 		context.Background(),
 		resource.WithAttributes(
@@ -69,6 +86,7 @@ func initOTELTracer(ctx context.Context, client otlptrace.Client) func(context.C
 		log.Fatalf("failed to set resources: %s", err)
 	}
 
+	// set the global OpenTelemetry tracer provider
 	otel.SetTracerProvider(
 		trace.NewTracerProvider(
 			trace.WithSampler(trace.AlwaysSample()),


### PR DESCRIPTION
- Configure flexible [**gRPC** and **HTTP** exporters](https://opentelemetry.io/docs/languages/go/exporters/#otlp) with custom endpoints and headers when initializing the tracer client. [^1]
- Implement `InitTrace()` function to initialize the OpenTelemetry tracer with system information (os, arch) as trace attributes, and configure trace sampling and batch processing.
- Add `go.opentelemetry.io/otel` dependencies `v1.35.0` [^2], including `otlptrace`, `sdk`, `otlptracehttp` and `otlptracegrpc` in `go.mod` file.

> related issue #458

[^1]: [OTLP Specification 1.5.0](https://opentelemetry.io/docs/specs/otlp)
[^2]: [`otel v1.35.0` dependencies](https://pkg.go.dev/go.opentelemetry.io/otel@v1.35.0)