### PR TITLE
Refactor trace exporter init and add stdout support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.35.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.35.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.35.0
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.35.0
 	go.opentelemetry.io/otel/sdk v1.35.0
 	golang.org/x/crypto v0.37.0
 	golang.org/x/net v0.39.0

--- a/src/util/otel/otel.go
+++ b/src/util/otel/otel.go
@@ -50,7 +50,7 @@ type Config struct {
 }
 
 // newGRPCClient creates a new gRPC client for OpenTelemetry.
-// https://opentelemetry.io/docs/languages/go/exporters/#otlp-traces-over-http
+// https://opentelemetry.io/docs/languages/go/exporters/#otlp-traces-over-grpc
 func newGRPCClient(endpoint string, headers map[string]string) otlptrace.Client {
 	return otlptracegrpc.NewClient(
 		otlptracegrpc.WithEndpoint(endpoint),

--- a/src/util/otel/otel.go
+++ b/src/util/otel/otel.go
@@ -53,6 +53,8 @@ type Config struct {
 	Headers    map[string]string
 }
 
+// exporterFunc is a function type that takes a context and config,
+// it's used to create a new OpenTelemetry trace exporter.
 type exporterFunc func(context.Context, Config) (trace.SpanExporter, error)
 
 // newStdoutExporter creates a new stdout exporter for OpenTelemetry traces.
@@ -60,6 +62,7 @@ type exporterFunc func(context.Context, Config) (trace.SpanExporter, error)
 func newStdoutTraceExporter(_ context.Context, _ Config) (trace.SpanExporter, error) {
 	return stdouttrace.New(
 		stdouttrace.WithPrettyPrint(),
+		stdouttrace.WithWriter(log.Writer()), // TODO: use custom writer
 	)
 }
 


### PR DESCRIPTION
- Refactor trace exporter initialization to use function-based approach with `exporterFunc` type.
- Update log messages to inform about the exporter type being used.
- Add `go.opentelemetry.io/otel/exporters/stdout/stdouttrace` to the go.mod file.
- Add `stdout` trace exporter support, it contains an implementation of the console trace exporter.
- Change default exporter from gRPC to stdout for unknown client types, as stdout is without net requests.

relate issue: #458