### PR TITLE
Refactor WebAuthn init function to accept context and config

### DIFF
--- a/src/cmd/web.go
+++ b/src/cmd/web.go
@@ -54,7 +54,9 @@ func runWeb(ctx context.Context, c *cli.Command) error {
 	// Override config by cli flag
 	config.OverrideConfigByFlag(ctx, c)
 	model.InitTables()
-	webauthn.InitWebAuthn()
+
+	// Initialize webauthn
+	webauthn.InitWebAuthn(ctx, config.Config.WebAuthn)
 
 	// Initialize the logger
 	ctx = context.WithValue(ctx, slogger.CtxVersionKey, version)

--- a/src/lib/webauthn/webauthn.go
+++ b/src/lib/webauthn/webauthn.go
@@ -1,6 +1,7 @@
 package webauthn
 
 import (
+	"context"
 	"encoding/json"
 	"log/slog"
 
@@ -12,16 +13,16 @@ import (
 
 var w *webauthn.WebAuthn
 
-func InitWebAuthn() {
+func InitWebAuthn(ctx context.Context, c config.WebAuthnConfig) {
 	var err error
-	config := config.Config.WebAuthn
 	if w, err = webauthn.New(&webauthn.Config{
-		RPID:          config.RPID,
-		RPDisplayName: config.RPDisplayName,
-		RPOrigins:     config.RPOrigins,
+		RPID:          c.RPID,
+		RPDisplayName: c.RPDisplayName,
+		RPOrigins:     c.RPOrigins,
 	}); err != nil {
 		slog.Error("new WebAuthn object error", slog.Any("error", err))
 	}
+	slog.Debug("init WebAuthn", slog.String("rpID", c.RPID))
 }
 
 // BeginRegister generates a new set of registration data for webauthn.


### PR DESCRIPTION
- Add context and config parameters to `InitWebAuthn` function.
- Initialize WebAuthn with the provided config param instead of global config.