### PR TITLE
Add support for log rolling files writer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	golang.org/x/net v0.39.0
 	google.golang.org/grpc v1.72.0
 	google.golang.org/protobuf v1.36.6
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	xorm.io/xorm v1.3.9
 )
 

--- a/src/util/slog/files_write.go
+++ b/src/util/slog/files_write.go
@@ -1,0 +1,20 @@
+package slogger
+
+import (
+	"io"
+
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+// NewFilesWriter creates a new rolling files writer.
+// It rotates the log file when it reaches a certain size, age...
+func NewFilesWriter(filename string) io.Writer {
+	return &lumberjack.Logger{
+		Filename:   filename,
+		MaxSize:    10, // megabytes
+		MaxAge:     30, // days
+		MaxBackups: 3,
+		LocalTime:  true,
+		Compress:   true,
+	}
+}

--- a/src/util/slog/files_write.go
+++ b/src/util/slog/files_write.go
@@ -2,6 +2,8 @@ package slogger
 
 import (
 	"io"
+	"log/slog"
+	"os"
 
 	"gopkg.in/natefinch/lumberjack.v2"
 )
@@ -9,6 +11,14 @@ import (
 // NewFilesWriter creates a new rolling files writer.
 // It rotates the log file when it reaches a certain size, age...
 func NewFilesWriter(filename string) io.Writer {
+	// TODO: check the file mode and permissions
+	_, err := os.Stat(filename)
+	if err != nil || os.IsNotExist(err) {
+		slog.Error("file not exist", slog.String("filename", filename), slog.Any("error", err))
+		return io.Discard // or instead of it use os.Stdout
+	}
+
+	// TODO: customize lumberjack settings
 	return &lumberjack.Logger{
 		Filename:   filename,
 		MaxSize:    10, // megabytes


### PR DESCRIPTION
- Add `gopkg.in/natefinch/lumberjack.v2` to the go.mod file.
- Implement `NewFilesWriter` function to create a rolling files writer.