### PR TITLE
Add OpenTelemetry integration for structured logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,11 +25,15 @@ require (
 	github.com/smartystreets/goconvey v1.8.1
 	github.com/urfave/cli/v3 v3.2.0
 	github.com/yuin/goldmark v1.7.10
+	go.opentelemetry.io/contrib/bridges/otelslog v0.10.0
 	go.opentelemetry.io/otel v1.35.0
+	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.11.0
+	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.11.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.35.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.35.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.35.0
 	go.opentelemetry.io/otel/sdk v1.35.0
+	go.opentelemetry.io/otel/sdk/log v0.11.0
 	golang.org/x/crypto v0.37.0
 	golang.org/x/net v0.39.0
 	google.golang.org/grpc v1.72.0
@@ -85,6 +89,7 @@ require (
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
+	go.opentelemetry.io/otel/log v0.11.0 // indirect
 	go.opentelemetry.io/otel/metric v1.35.0 // indirect
 	go.opentelemetry.io/otel/trace v1.35.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.5.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.35.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.35.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.35.0
+	go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.11.0
 	go.opentelemetry.io/otel/sdk v1.35.0
 	go.opentelemetry.io/otel/sdk/log v0.11.0
 	golang.org/x/crypto v0.37.0

--- a/src/util/otel/log.go
+++ b/src/util/otel/log.go
@@ -1,0 +1,77 @@
+package otel
+
+import (
+	"context"
+	"log"
+	"log/slog"
+	"runtime"
+
+	"go.opentelemetry.io/contrib/bridges/otelslog"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+	"go.opentelemetry.io/otel/sdk/resource"
+)
+
+func InitLog(ctx context.Context, c Config) *slog.Logger {
+	var exporter sdklog.Exporter
+	var err error
+	switch c.ClientType {
+	case "grpc":
+		slog.Debug("init otel log grpc client")
+		exporter, err = newGRPCExporter(ctx, c)
+	case "http":
+		slog.Debug("init otel log http client")
+		exporter, err = newHTTPExporter(ctx, c)
+	default:
+		slog.Warn("unknown otel log client", slog.String("client", c.ClientType))
+		slog.Debug("init otel log client with default grpc")
+		exporter, err = newGRPCExporter(ctx, c)
+	}
+	if err != nil {
+		log.Fatalf("failed to create exporter: %s", err)
+	}
+
+	// create the resource
+	resources, err := resource.New(ctx,
+		resource.WithAttributes(
+			attribute.String("service.name", "go-xn"),
+			attribute.String("service.os", runtime.GOOS),
+			attribute.String("service.arch", runtime.GOARCH),
+		),
+	)
+	if err != nil {
+		log.Fatalf("failed to set resources: %s", err)
+	}
+
+	// Initialize the logger provider
+	loggerProvider := sdklog.NewLoggerProvider(
+		sdklog.WithProcessor(sdklog.NewBatchProcessor(exporter)),
+		sdklog.WithResource(resources),
+	)
+
+	logger := otelslog.NewLogger("go-xn",
+		otelslog.WithLoggerProvider(loggerProvider),
+	)
+
+	return logger
+}
+
+// newGRPCExporter creates a new gRPC exporter for OpenTelemetry logs.
+// https://opentelemetry.io/docs/languages/go/exporters/#otlp-logs-over-grpc-experimental
+func newGRPCExporter(ctx context.Context, c Config) (*otlploggrpc.Exporter, error) {
+	return otlploggrpc.New(ctx,
+		otlploggrpc.WithEndpoint(c.Endpoint),
+		otlploggrpc.WithHeaders(c.Headers),
+	)
+}
+
+// newHTTPExporter creates a new HTTP exporter for OpenTelemetry logs.
+// https://opentelemetry.io/docs/languages/go/exporters/#otlp-logs-over-http-experimental
+func newHTTPExporter(ctx context.Context, c Config) (*otlploghttp.Exporter, error) {
+	return otlploghttp.New(ctx,
+		otlploghttp.WithEndpoint(c.Endpoint),
+		otlploghttp.WithHeaders(c.Headers),
+	)
+}


### PR DESCRIPTION
- Configure flexible stdout, GRPC and HTTP exporters with custom endpoints and headers in initalizating the logger. [^1]
- Implement `InitLog()` function to initialize the OpenTelemetry logger with system information (os, arch) as log attributes, and configure log processing and resource attributes.
- Add `go.opentelemetry.io/otel` dependencies, including `otlplog`, `sdk/log`, `otlploggrpc`, and `otlploghttp` in `go.mod` file.
- Add `go.opentelemetry.io/contrib/bridges/otelslog` dependency v0.10.0 [^2] for OpenTelemetry structured logging.

> related issue #458

[^1]: [OTLP logs over HTTP / gRPC](https://opentelemetry.io/docs/languages/go/exporters/#otlp-logs-over-http-experimental)
[^2]: [otelslog v0.10.0 dependency](https://pkg.go.dev/go.opentelemetry.io/contrib/bridges/otelslog@v0.10.0)