### PR TITLE
fix: exclude file not exist error and check for directory

### DIFF
--- a/src/util/slog/files_write.go
+++ b/src/util/slog/files_write.go
@@ -11,11 +11,16 @@ import (
 // NewFilesWriter creates a new rolling files writer.
 // It rotates the log file when it reaches a certain size, age...
 func NewFilesWriter(filename string) io.Writer {
+	finfo, err := os.Stat(filename)
+	if err != nil && !os.IsNotExist(err) {
+		slog.Error("failed to stat log file", slog.String("filename", filename), slog.Any("error", err))
+		return io.Discard // or use `os.Stdout` instead
+	}
+
 	// TODO: check the file mode and permissions
-	_, err := os.Stat(filename)
-	if err != nil || os.IsNotExist(err) {
-		slog.Error("file not exist", slog.String("filename", filename), slog.Any("error", err))
-		return io.Discard // or instead of it use os.Stdout
+	if finfo.IsDir() {
+		slog.Error("log file is a directory", slog.String("filename", filename))
+		return io.Discard
 	}
 
 	// TODO: customize lumberjack settings


### PR DESCRIPTION
- Add a check whether the filepath is a directory.
- Update error handling in NewFilesWriter to exclude `os.IsNotExist`.