### PR TITLE
refactor: separate slog logger creation from provider init

### DIFF
--- a/src/util/otel/log.go
+++ b/src/util/otel/log.go
@@ -11,11 +11,22 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
 	"go.opentelemetry.io/otel/exporters/stdout/stdoutlog"
+	otellog "go.opentelemetry.io/otel/log"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 	"go.opentelemetry.io/otel/sdk/resource"
 )
 
-func InitLog(ctx context.Context, c Config) *slog.Logger {
+func NewLogger(ctx context.Context, c Config) *slog.Logger {
+	loggerProvider := InitLog(ctx, c)
+
+	logger := otelslog.NewLogger("go-xn",
+		otelslog.WithLoggerProvider(loggerProvider),
+	)
+
+	return logger
+}
+
+func InitLog(ctx context.Context, c Config) otellog.LoggerProvider {
 	var exporterFn func(context.Context, Config) (sdklog.Exporter, error)
 	switch c.ClientType {
 	case "grpc":
@@ -55,11 +66,7 @@ func InitLog(ctx context.Context, c Config) *slog.Logger {
 		sdklog.WithResource(resources),
 	)
 
-	logger := otelslog.NewLogger("go-xn",
-		otelslog.WithLoggerProvider(loggerProvider),
-	)
-
-	return logger
+	return loggerProvider
 }
 
 // newStdoutExporter creates a new stdout exporter for OpenTelemetry logs.


### PR DESCRIPTION
- Update `InitLog` function to solely initialize and return an `otellog.LoggerProvider`.
- Add `NewLogger` function to create `slog.Logger` using the logger provider from `InitLog`.