### PR TITLE
Bump otel log-related dependencies to v0.12.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,16 +34,16 @@ require (
 	github.com/yuin/goldmark v1.7.12
 	go.opentelemetry.io/contrib/bridges/otelslog v0.10.0
 	go.opentelemetry.io/otel v1.36.0
-	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.11.0
-	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.11.0
+	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.12.2
+	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.12.2
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.36.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.36.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.36.0
-	go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.11.0
+	go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.12.2
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.36.0
-	go.opentelemetry.io/otel/log v0.11.0
+	go.opentelemetry.io/otel/log v0.12.2
 	go.opentelemetry.io/otel/sdk v1.36.0
-	go.opentelemetry.io/otel/sdk/log v0.11.0
+	go.opentelemetry.io/otel/sdk/log v0.12.2
 	golang.org/x/crypto v0.38.0
 	golang.org/x/net v0.40.0
 	google.golang.org/grpc v1.72.1
@@ -57,7 +57,6 @@ require (
 	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc // indirect
 	github.com/bytedance/sonic v1.12.10 // indirect
 	github.com/bytedance/sonic/loader v0.2.3 // indirect
-	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.5 // indirect


### PR DESCRIPTION
* Upgrade OpenTelemetry log-related dependencies to the latest versions `v0.12.2`. This includes:
  - `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc` from v0.11.0 to v0.12.2
  - `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp` from v0.11.0 to v0.12.2
  - `go.opentelemetry.io/otel/exporters/stdout/stdoutlog` from v0.11.0 to v0.12.2
  - `go.opentelemetry.io/otel/log` from v0.11.0 to v0.12.2
  - `go.opentelemetry.io/otel/sdk/log` from v0.11.0 to v0.12.2

* Removed unused indirect dependencies by running `go mod tidy` command.