### PR TITLE
Implement OpenTelemetry metrics collection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,14 +36,18 @@ require (
 	go.opentelemetry.io/otel v1.35.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.11.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.11.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.35.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.35.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.35.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.35.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.35.0
 	go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.11.0
+	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.35.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.35.0
 	go.opentelemetry.io/otel/log v0.11.0
 	go.opentelemetry.io/otel/sdk v1.35.0
 	go.opentelemetry.io/otel/sdk/log v0.11.0
+	go.opentelemetry.io/otel/sdk/metric v1.35.0
 	golang.org/x/crypto v0.38.0
 	golang.org/x/net v0.40.0
 	google.golang.org/grpc v1.72.1

--- a/src/util/otel/metric.go
+++ b/src/util/otel/metric.go
@@ -1,0 +1,93 @@
+package otel
+
+import (
+	"context"
+	"log"
+	"log/slog"
+	"runtime"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
+	"go.opentelemetry.io/otel/exporters/stdout/stdoutmetric"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+)
+
+// InitTrace initializes the OpenTelemetry trace exporter with the given config.
+// It returns a function to shut down the exporter when done.
+func InitMetric(ctx context.Context, c Config) func(context.Context) error {
+	var metricExporter metricFunc
+	switch c.ClientType {
+	case "grpc":
+		slog.Debug("init otel metric", slog.String("type", c.ClientType))
+		metricExporter = newGRPCMetricExporter
+	case "http":
+		slog.Debug("init otel metric", slog.String("type", c.ClientType))
+		metricExporter = newHTTPMetricExporter
+	case "stdout":
+		slog.Debug("init otel metric", slog.String("type", c.ClientType))
+		metricExporter = newStdoutMetricExporter
+	default:
+		slog.Warn("unknown otel metric type", slog.String("type", c.ClientType))
+		slog.Debug("init otel metric with default stdout")
+		metricExporter = newStdoutMetricExporter
+	}
+
+	exporter, err := metricExporter(ctx, c)
+	if err != nil {
+		log.Fatal("failed to create metric exporter: ", err)
+	}
+
+	// Create new resource
+	resources, err := resource.New(ctx,
+		resource.WithAttributes(
+			attribute.String("service.name", "go-xn"),
+			attribute.String("service.os", runtime.GOOS),
+			attribute.String("service.arch", runtime.GOARCH),
+		),
+	)
+	if err != nil {
+		log.Fatal("failed to create resource: ", err)
+	}
+
+	otel.SetMeterProvider(
+		metric.NewMeterProvider(
+			metric.WithReader(metric.NewPeriodicReader(exporter)),
+			metric.WithResource(resources),
+		),
+	)
+
+	return exporter.Shutdown
+}
+
+// metricFunc is a function that creates an OpenTelemetry exporter.
+type metricFunc func(context.Context, Config) (metric.Exporter, error)
+
+// newStdoutMetricExporter creates a new stdout exporter for OpenTelemetry metrics.
+// https://opentelemetry.io/docs/languages/go/exporters/#console-metrics
+func newStdoutMetricExporter(_ context.Context, _ Config) (metric.Exporter, error) {
+	return stdoutmetric.New(
+		stdoutmetric.WithPrettyPrint(),
+		stdoutmetric.WithWriter(log.Writer()), // TODO: use custom writer
+	)
+}
+
+// newGRPCMetricExporter creates a new gRPC exporter for OpenTelemetry metrics.
+// https://opentelemetry.io/docs/languages/go/exporters/#otlp-metrics-over-grpc
+func newGRPCMetricExporter(ctx context.Context, c Config) (metric.Exporter, error) {
+	return otlpmetricgrpc.New(ctx,
+		otlpmetricgrpc.WithEndpoint(c.Endpoint),
+		otlpmetricgrpc.WithHeaders(c.Headers),
+	)
+}
+
+// newHTTPMetricExporter creates a new HTTP exporter for OpenTelemetry metrics.
+// https://opentelemetry.io/docs/languages/go/exporters/#otlp-metrics-over-http
+func newHTTPMetricExporter(ctx context.Context, c Config) (metric.Exporter, error) {
+	return otlpmetrichttp.New(ctx,
+		otlpmetrichttp.WithEndpoint(c.Endpoint),
+		otlpmetrichttp.WithHeaders(c.Headers),
+	)
+}


### PR DESCRIPTION
- Configure flexible GRPC/HTTP exporters with custom endpoints and headers in initalizating the metric exporter. [^1]
- Add `stdout` metric exporter support, a console-based exporter for OpenTelemetry metrics. [^2]
- Implement `InitMetric` function to initialize the OpenTelemetry metric with system information (os, arch) as log attributes, and configure periodic metric collection.
- Add `go.opentelemetry.io/otel` dependency, including `otlpmetric`, `sdk/metric`, `otlpmetricgrpc`, and `otlpmetrichttp` in `go.mod` file.

> related issue #458

[^1]: [OTLP metrics over HTTP / gRPC](https://opentelemetry.io/docs/languages/go/exporters/#otlp-metrics-over-http)
[^2]: [OTLP Console metrics](https://opentelemetry.io/docs/languages/go/exporters/#console-metrics)