### PR TITLE
refactor: change `InitLog` return type from interface to concrete type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,6 @@ require (
 	go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.12.2
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.36.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.36.0
-	go.opentelemetry.io/otel/log v0.12.2
 	go.opentelemetry.io/otel/sdk v1.36.0
 	go.opentelemetry.io/otel/sdk/log v0.12.2
 	go.opentelemetry.io/otel/sdk/metric v1.36.0
@@ -97,6 +96,7 @@ require (
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
+	go.opentelemetry.io/otel/log v0.12.2 // indirect
 	go.opentelemetry.io/otel/metric v1.36.0 // indirect
 	go.opentelemetry.io/otel/trace v1.36.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.6.0 // indirect

--- a/src/util/otel/log.go
+++ b/src/util/otel/log.go
@@ -11,7 +11,6 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
 	"go.opentelemetry.io/otel/exporters/stdout/stdoutlog"
-	otellog "go.opentelemetry.io/otel/log"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 	"go.opentelemetry.io/otel/sdk/resource"
 )
@@ -26,7 +25,7 @@ func NewLogger(ctx context.Context, c Config) *slog.Logger {
 	return logger
 }
 
-func InitLog(ctx context.Context, c Config) otellog.LoggerProvider {
+func InitLog(ctx context.Context, c Config) *sdklog.LoggerProvider {
 	var exporterFn func(context.Context, Config) (sdklog.Exporter, error)
 	switch c.ClientType {
 	case "grpc":


### PR DESCRIPTION
- Replace the `otellog.LoggerProvider` interface return type with the concrete `*sdklog.LoggerProvider` type in the **`InitLog`** function.
- Move `go.opentelemetry.io/otel/sdk/log` dependency to the indirect **`require`** section in go.mod file.

> related PR: #466