### PR TITLE
Optimize otel resource attribute by shared function

### DIFF
--- a/src/util/otel/log.go
+++ b/src/util/otel/log.go
@@ -4,15 +4,12 @@ import (
 	"context"
 	"log"
 	"log/slog"
-	"runtime"
 
 	"go.opentelemetry.io/contrib/bridges/otelslog"
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
 	"go.opentelemetry.io/otel/exporters/stdout/stdoutlog"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
-	"go.opentelemetry.io/otel/sdk/resource"
 )
 
 func NewLogger(ctx context.Context, c Config) *slog.Logger {
@@ -48,13 +45,7 @@ func InitLog(ctx context.Context, c Config) *sdklog.LoggerProvider {
 	}
 
 	// create the resource
-	resources, err := resource.New(ctx,
-		resource.WithAttributes(
-			attribute.String("service.name", "go-xn"),
-			attribute.String("service.os", runtime.GOOS),
-			attribute.String("service.arch", runtime.GOARCH),
-		),
-	)
+	resources, err := commonResource(ctx)
 	if err != nil {
 		log.Fatalf("failed to set resources: %s", err)
 	}

--- a/src/util/otel/metric.go
+++ b/src/util/otel/metric.go
@@ -4,15 +4,12 @@ import (
 	"context"
 	"log"
 	"log/slog"
-	"runtime"
 
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/exporters/stdout/stdoutmetric"
 	"go.opentelemetry.io/otel/sdk/metric"
-	"go.opentelemetry.io/otel/sdk/resource"
 )
 
 // InitTrace initializes the OpenTelemetry trace exporter with the given config.
@@ -41,13 +38,7 @@ func InitMetric(ctx context.Context, c Config) func(context.Context) error {
 	}
 
 	// Create new resource
-	resources, err := resource.New(ctx,
-		resource.WithAttributes(
-			attribute.String("service.name", "go-xn"),
-			attribute.String("service.os", runtime.GOOS),
-			attribute.String("service.arch", runtime.GOARCH),
-		),
-	)
+	resources, err := commonResource(ctx)
 	if err != nil {
 		log.Fatal("failed to create resource: ", err)
 	}

--- a/src/util/otel/resource.go
+++ b/src/util/otel/resource.go
@@ -1,0 +1,21 @@
+package otel
+
+import (
+	"context"
+	"runtime"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/resource"
+)
+
+// commonResource returns a common resource with service name, OS, and arch.
+func commonResource(ctx context.Context) (*resource.Resource, error) {
+	return resource.New(ctx,
+		resource.WithAttributes(
+			attribute.String("service.name", "go-xn"),
+			attribute.String("os.type", runtime.GOOS),
+			attribute.String("os.arch", runtime.GOARCH),
+		),
+		resource.WithHost(),
+	)
+}

--- a/src/util/otel/trace.go
+++ b/src/util/otel/trace.go
@@ -4,15 +4,12 @@ import (
 	"context"
 	"log"
 	"log/slog"
-	"runtime"
 
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
-	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
 )
 
@@ -83,13 +80,7 @@ func initOTELTracer(ctx context.Context, c Config, fn exporterFunc) func(context
 	}
 
 	// create the resource
-	resources, err := resource.New(ctx,
-		resource.WithAttributes(
-			attribute.String("service.name", "go-xn"),
-			attribute.String("service.os", runtime.GOOS),
-			attribute.String("service.arch", runtime.GOARCH),
-		),
-	)
+	resources, err := commonResource(ctx)
 	if err != nil {
 		log.Fatalf("failed to set resources: %s", err)
 	}


### PR DESCRIPTION
- Create `resource.go` file with `commonResource()` function to eliminate code duplication.
- Extract duplicate OpenTelemetry resource creation logic into a shared function, as `commonResource()`.
- Update resource attributes to use more standard naming conventions (`os.type` and `os.arch` instead of `service.os` and `service.arch`).
- Add `resource.WithHost()` to include additional host information in the shared resource.