### PR TITLE
tweak: update otel config to private type

### DIFF
--- a/src/util/otel/config.go
+++ b/src/util/otel/config.go
@@ -1,6 +1,6 @@
 package otel
 
-// Config is the configuration for [OpenTelemetry].
+// config is the configuration for [OpenTelemetry].
 // It contains the client type, endpoint, and headers for the exporter.
 // The client type can be either "grpc" or "http".
 // The endpoint is the URL of the [OpenTelemetry Collector], default not including `v1/trace`.
@@ -8,16 +8,16 @@ package otel
 //
 // [OpenTelemetry]: https://opentelemetry.io/
 // [OpenTelemetry Collector]: https://opentelemetry.io/docs/collector/
-type Config struct {
+type config struct {
 	ClientType string
 	Endpoint   string
 	Headers    map[string]string
 }
 
-// NewConfig creates a new Config with default values,
+// NewConfig creates a new config with default values,
 // and applies any provided options to customize it.
-func NewConfig(opts ...Option) *Config {
-	c := &Config{
+func NewConfig(opts ...Option) *config {
+	c := &config{
 		ClientType: "grpc",                  // default client type
 		Endpoint:   "localhost:4317",        // default endpoint
 		Headers:    make(map[string]string), // default empty headers
@@ -30,26 +30,26 @@ func NewConfig(opts ...Option) *Config {
 	return c
 }
 
-// Option is a function that modifies the Config.
-type Option func(*Config)
+// Option is a function that modifies the config.
+type Option func(*config)
 
 // WithClientType sets the client type for the OpenTelemetry exporter.
 func WithClientType(clientType string) Option {
-	return func(c *Config) {
+	return func(c *config) {
 		c.ClientType = clientType
 	}
 }
 
 // WithEndpoint sets the endpoint for the OpenTelemetry exporter.
 func WithEndpoint(endpoint string) Option {
-	return func(c *Config) {
+	return func(c *config) {
 		c.Endpoint = endpoint
 	}
 }
 
 // WithHeaders sets the headers for the OpenTelemetry exporter.
 func WithHeaders(headers map[string]string) Option {
-	return func(c *Config) {
+	return func(c *config) {
 		c.Headers = headers
 	}
 }

--- a/src/util/otel/log.go
+++ b/src/util/otel/log.go
@@ -12,7 +12,7 @@ import (
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 )
 
-func NewLogger(ctx context.Context, c Config) *slog.Logger {
+func NewLogger(ctx context.Context, c config) *slog.Logger {
 	loggerProvider := InitLog(ctx, c)
 
 	logger := otelslog.NewLogger("go-xn",
@@ -22,8 +22,8 @@ func NewLogger(ctx context.Context, c Config) *slog.Logger {
 	return logger
 }
 
-func InitLog(ctx context.Context, c Config) *sdklog.LoggerProvider {
-	var exporterFn func(context.Context, Config) (sdklog.Exporter, error)
+func InitLog(ctx context.Context, c config) *sdklog.LoggerProvider {
+	var exporterFn func(context.Context, config) (sdklog.Exporter, error)
 	switch c.ClientType {
 	case "grpc":
 		slog.Debug("init otel log", slog.String("type", c.ClientType))
@@ -61,7 +61,7 @@ func InitLog(ctx context.Context, c Config) *sdklog.LoggerProvider {
 
 // newStdoutExporter creates a new stdout exporter for OpenTelemetry logs.
 // https://opentelemetry.io/docs/languages/go/exporters/#console-logs
-func newStdoutLogExporter(_ context.Context, _ Config) (sdklog.Exporter, error) {
+func newStdoutLogExporter(_ context.Context, _ config) (sdklog.Exporter, error) {
 	return stdoutlog.New(
 		stdoutlog.WithPrettyPrint(),
 		stdoutlog.WithWriter(log.Writer()), // TODO: use custom writer
@@ -70,7 +70,7 @@ func newStdoutLogExporter(_ context.Context, _ Config) (sdklog.Exporter, error) 
 
 // newGRPCExporter creates a new gRPC exporter for OpenTelemetry logs.
 // https://opentelemetry.io/docs/languages/go/exporters/#otlp-logs-over-grpc-experimental
-func newGRPCLogExporter(ctx context.Context, c Config) (sdklog.Exporter, error) {
+func newGRPCLogExporter(ctx context.Context, c config) (sdklog.Exporter, error) {
 	return otlploggrpc.New(ctx,
 		otlploggrpc.WithEndpoint(c.Endpoint),
 		otlploggrpc.WithHeaders(c.Headers),
@@ -79,7 +79,7 @@ func newGRPCLogExporter(ctx context.Context, c Config) (sdklog.Exporter, error) 
 
 // newHTTPExporter creates a new HTTP exporter for OpenTelemetry logs.
 // https://opentelemetry.io/docs/languages/go/exporters/#otlp-logs-over-http-experimental
-func newHTTPLogExporter(ctx context.Context, c Config) (sdklog.Exporter, error) {
+func newHTTPLogExporter(ctx context.Context, c config) (sdklog.Exporter, error) {
 	return otlploghttp.New(ctx,
 		otlploghttp.WithEndpoint(c.Endpoint),
 		otlploghttp.WithHeaders(c.Headers),

--- a/src/util/otel/metric.go
+++ b/src/util/otel/metric.go
@@ -14,7 +14,7 @@ import (
 
 // InitTrace initializes the OpenTelemetry trace exporter with the given config.
 // It returns a function to shut down the exporter when done.
-func InitMetric(ctx context.Context, c Config) func(context.Context) error {
+func InitMetric(ctx context.Context, c config) func(context.Context) error {
 	var metricExporter metricFunc
 	switch c.ClientType {
 	case "grpc":
@@ -54,11 +54,11 @@ func InitMetric(ctx context.Context, c Config) func(context.Context) error {
 }
 
 // metricFunc is a function that creates an OpenTelemetry exporter.
-type metricFunc func(context.Context, Config) (metric.Exporter, error)
+type metricFunc func(context.Context, config) (metric.Exporter, error)
 
 // newStdoutMetricExporter creates a new stdout exporter for OpenTelemetry metrics.
 // https://opentelemetry.io/docs/languages/go/exporters/#console-metrics
-func newStdoutMetricExporter(_ context.Context, _ Config) (metric.Exporter, error) {
+func newStdoutMetricExporter(_ context.Context, _ config) (metric.Exporter, error) {
 	return stdoutmetric.New(
 		stdoutmetric.WithPrettyPrint(),
 		stdoutmetric.WithWriter(log.Writer()), // TODO: use custom writer
@@ -67,7 +67,7 @@ func newStdoutMetricExporter(_ context.Context, _ Config) (metric.Exporter, erro
 
 // newGRPCMetricExporter creates a new gRPC exporter for OpenTelemetry metrics.
 // https://opentelemetry.io/docs/languages/go/exporters/#otlp-metrics-over-grpc
-func newGRPCMetricExporter(ctx context.Context, c Config) (metric.Exporter, error) {
+func newGRPCMetricExporter(ctx context.Context, c config) (metric.Exporter, error) {
 	return otlpmetricgrpc.New(ctx,
 		otlpmetricgrpc.WithEndpoint(c.Endpoint),
 		otlpmetricgrpc.WithHeaders(c.Headers),
@@ -76,7 +76,7 @@ func newGRPCMetricExporter(ctx context.Context, c Config) (metric.Exporter, erro
 
 // newHTTPMetricExporter creates a new HTTP exporter for OpenTelemetry metrics.
 // https://opentelemetry.io/docs/languages/go/exporters/#otlp-metrics-over-http
-func newHTTPMetricExporter(ctx context.Context, c Config) (metric.Exporter, error) {
+func newHTTPMetricExporter(ctx context.Context, c config) (metric.Exporter, error) {
 	return otlpmetrichttp.New(ctx,
 		otlpmetrichttp.WithEndpoint(c.Endpoint),
 		otlpmetrichttp.WithHeaders(c.Headers),

--- a/src/util/otel/trace.go
+++ b/src/util/otel/trace.go
@@ -15,7 +15,7 @@ import (
 
 // InitTrace initializes the OpenTelemetry trace exporter with the given config.
 // It returns a function to shut down the exporter when done.
-func InitTrace(ctx context.Context, c Config) func(context.Context) error {
+func InitTrace(ctx context.Context, c config) func(context.Context) error {
 	var exporterFn exporterFunc
 	switch c.ClientType {
 	case "grpc":
@@ -38,11 +38,11 @@ func InitTrace(ctx context.Context, c Config) func(context.Context) error {
 
 // exporterFunc is a function type that takes a context and config,
 // it's used to create a new OpenTelemetry trace exporter.
-type exporterFunc func(context.Context, Config) (trace.SpanExporter, error)
+type exporterFunc func(context.Context, config) (trace.SpanExporter, error)
 
 // newStdoutExporter creates a new stdout exporter for OpenTelemetry traces.
 // https://opentelemetry.io/docs/languages/go/exporters/#console-traces
-func newStdoutTraceExporter(_ context.Context, _ Config) (trace.SpanExporter, error) {
+func newStdoutTraceExporter(_ context.Context, _ config) (trace.SpanExporter, error) {
 	return stdouttrace.New(
 		stdouttrace.WithPrettyPrint(),
 		stdouttrace.WithWriter(log.Writer()), // TODO: use custom writer
@@ -51,7 +51,7 @@ func newStdoutTraceExporter(_ context.Context, _ Config) (trace.SpanExporter, er
 
 // newGRPCExporter creates a new gRPC exporter for OpenTelemetry traces.
 // https://opentelemetry.io/docs/languages/go/exporters/#otlp-traces-over-grpc
-func newGRPCTraceExporter(ctx context.Context, c Config) (trace.SpanExporter, error) {
+func newGRPCTraceExporter(ctx context.Context, c config) (trace.SpanExporter, error) {
 	return otlptrace.New(ctx,
 		otlptracegrpc.NewClient(
 			otlptracegrpc.WithEndpoint(c.Endpoint),
@@ -62,7 +62,7 @@ func newGRPCTraceExporter(ctx context.Context, c Config) (trace.SpanExporter, er
 
 // newHTTPExporter creates a new HTTP exporter for OpenTelemetry traces.
 // https://opentelemetry.io/docs/languages/go/exporters/#otlp-traces-over-http
-func newHTTPTraceExporter(ctx context.Context, c Config) (trace.SpanExporter, error) {
+func newHTTPTraceExporter(ctx context.Context, c config) (trace.SpanExporter, error) {
 	return otlptrace.New(ctx,
 		otlptracehttp.NewClient(
 			otlptracehttp.WithEndpoint(c.Endpoint),
@@ -72,7 +72,7 @@ func newHTTPTraceExporter(ctx context.Context, c Config) (trace.SpanExporter, er
 }
 
 // initOTELTracer initializes the OpenTelemetry tracer with the given client.
-func initOTELTracer(ctx context.Context, c Config, fn exporterFunc) func(context.Context) error {
+func initOTELTracer(ctx context.Context, c config, fn exporterFunc) func(context.Context) error {
 	// create the exporter
 	exporter, err := fn(ctx, c)
 	if err != nil {


### PR DESCRIPTION
- Changed `Config` struct to `config` (unexported) in otel package.
- Updated all references from Config to config across trace, metric, and log modules.
- Updated function signatures and comments to reflect the private config type.