### PR TITLE
tweak: use pointer as param type for otel init functions

### DIFF
--- a/src/util/otel/log.go
+++ b/src/util/otel/log.go
@@ -12,7 +12,7 @@ import (
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 )
 
-func NewLogger(ctx context.Context, c config) *slog.Logger {
+func NewLogger(ctx context.Context, c *config) *slog.Logger {
 	loggerProvider := InitLog(ctx, c)
 
 	logger := otelslog.NewLogger("go-xn",
@@ -22,7 +22,7 @@ func NewLogger(ctx context.Context, c config) *slog.Logger {
 	return logger
 }
 
-func InitLog(ctx context.Context, c config) *sdklog.LoggerProvider {
+func InitLog(ctx context.Context, c *config) *sdklog.LoggerProvider {
 	var exporterFn func(context.Context, config) (sdklog.Exporter, error)
 	switch c.ClientType {
 	case "grpc":
@@ -39,7 +39,7 @@ func InitLog(ctx context.Context, c config) *sdklog.LoggerProvider {
 		slog.Debug("init otel log with default stdout")
 		exporterFn = newStdoutLogExporter
 	}
-	exporter, err := exporterFn(ctx, c)
+	exporter, err := exporterFn(ctx, *c)
 	if err != nil {
 		log.Fatalf("failed to create log exporter: %s", err)
 	}

--- a/src/util/otel/metric.go
+++ b/src/util/otel/metric.go
@@ -14,7 +14,7 @@ import (
 
 // InitTrace initializes the OpenTelemetry trace exporter with the given config.
 // It returns a function to shut down the exporter when done.
-func InitMetric(ctx context.Context, c config) func(context.Context) error {
+func InitMetric(ctx context.Context, c *config) func(context.Context) error {
 	var metricExporter metricFunc
 	switch c.ClientType {
 	case "grpc":
@@ -32,7 +32,7 @@ func InitMetric(ctx context.Context, c config) func(context.Context) error {
 		metricExporter = newStdoutMetricExporter
 	}
 
-	exporter, err := metricExporter(ctx, c)
+	exporter, err := metricExporter(ctx, *c)
 	if err != nil {
 		log.Fatal("failed to create metric exporter: ", err)
 	}

--- a/src/util/otel/trace.go
+++ b/src/util/otel/trace.go
@@ -15,7 +15,7 @@ import (
 
 // InitTrace initializes the OpenTelemetry trace exporter with the given config.
 // It returns a function to shut down the exporter when done.
-func InitTrace(ctx context.Context, c config) func(context.Context) error {
+func InitTrace(ctx context.Context, c *config) func(context.Context) error {
 	var exporterFn exporterFunc
 	switch c.ClientType {
 	case "grpc":
@@ -33,7 +33,7 @@ func InitTrace(ctx context.Context, c config) func(context.Context) error {
 		exporterFn = newStdoutTraceExporter
 	}
 
-	return initOTELTracer(ctx, c, exporterFn)
+	return initOTELTracer(ctx, *c, exporterFn)
 }
 
 // initOTELTracer initializes the OpenTelemetry tracer with the given client.


### PR DESCRIPTION
Update OpenTelemetry init functions to accept `*config` pointer param instead of `config` value,
to avoid struct copying, and to maintain consistency with other parts of the codebase.

Before:
```go
config := otel.NewConfig()   // return value
otel.InitTrace(ctx, &config) // pass by pointer
```

After:
```go
config := otel.NewConfig() // return pointer and pass it directly
otel.InitTrace(ctx, config)

// or directly use
otel.InitTrace(ctx, otel.NewConfig())
```