### PR TITLE
Release `0.1.0` version

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,38 @@
 
 ## [Unreleased]
 
+## [0.1.0] - 2025-06-18
+
+### Added
+
+- Implement OpenTelemetry metrics collection. (#490)
+- Add OpenTelemetry integration for structured logging. (#466)
+- Refactor trace exporter and add stdout support (#460)
+- Add support for log rolling files writer. (#465)
+- Define `defaultTimeout` constant as common timeout value. (ee84379)
+
+### Changed
+
+- Tweak directives order in `go.mod`. (4f1b546)
+- refactor: separate slog logger creation from provider init. (#471)
+- Rename `newrelic.go` file with `_write` suffix. (9757acc)
+- Rename `otel.go` file to `trace.go`. (d28462e)
+- Update error log messages to specific exporter type. (8730309)
+- Refactor WebAuthn init function to accept context and config. (#463)
+- refactor: change `InitLog` return type from interface to concrete type. (#493)
+- Optimize otel config constructor with functional options. (#495)
+- Optimize otel resource attribute by shared function. (#496)
+- Setup `ReplaceAttr` option to colorize error messages. (#501)
+- Sync Chinese translation language file for inno-setup. (#504)
+- tweak: update otel config to private type. (#507)
+- tweak: use pointer as param type for otel init functions. (#508)
+
+### Fixed
+
+- Fix typo and regenerate proto files. (#478)
+- fix: exclude file not exist error and check for directory. (#470)
+- fix: correct trace exporter client implementations. (#469)
+
 ## [0.0.7] - 2025-04-26
 
 ### Added
@@ -196,7 +228,8 @@
 
 - Release first version `0.0.1`.
 
-[Unreleased]: https://github.com/Pengxn/go-xn/compare/0.0.7...HEAD
+[Unreleased]: https://github.com/Pengxn/go-xn/compare/0.1.0...HEAD
+[0.1.0]: https://github.com/Pengxn/go-xn/compare/0.0.7...0.1.0
 [0.0.7]: https://github.com/Pengxn/go-xn/compare/0.0.6...0.0.7
 [0.0.6]: https://github.com/Pengxn/go-xn/compare/0.0.5...0.0.6
 [0.0.5]: https://github.com/Pengxn/go-xn/compare/0.0.4...0.0.5

--- a/script/windows/go-xn.iss
+++ b/script/windows/go-xn.iss
@@ -5,7 +5,7 @@
 ;     [guid]::NewGuid().ToString()
 #define APP_ID '9F00A778-1C16-4F7D-8FE4-0CDE4FC712DD'
 #define APP_NAME 'Go-xn'
-#define VERSION '0.0.7'
+#define VERSION '0.1.0'
 #define PUBLISHER 'xn-02f Lab'
 #define URL 'https://xn--02f.com'
 #define EXE_NAME 'go-xn.exe'

--- a/web/assets/js/main.js
+++ b/web/assets/js/main.js
@@ -1,4 +1,4 @@
-const APP_VERSION = '0.0.7'
+const APP_VERSION = '0.1.0'
 let YEAR = new Date().getFullYear()
 
 /**

--- a/web/humans.txt
+++ b/web/humans.txt
@@ -13,7 +13,7 @@
 	GitHub Contributors: Peng.xn (@Pengxn) and others。
 
 /* SITE */
-	Version: 0.0.7
-	Last Update: 2025/04/26
+	Version: 0.1.0
+	Last Update: 2025/06/18
 	Language: Chinese / English
 	Source Code: https://github.com/Pengxn/go-xn


### PR DESCRIPTION
Release `0.1.0` version, refer to [milestone 0.1.0](https://github.com/Pengxn/go-xn/milestone/2).