### PR TITLE
Simplify OpenTelemetry trace exporter implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.13.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.37.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.37.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.37.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.37.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.37.0
 	go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.13.0
@@ -96,6 +95,7 @@ require (
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.37.0 // indirect
 	go.opentelemetry.io/otel/log v0.13.0 // indirect
 	go.opentelemetry.io/otel/metric v1.37.0 // indirect
 	go.opentelemetry.io/otel/trace v1.37.0 // indirect

--- a/src/util/otel/trace.go
+++ b/src/util/otel/trace.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
@@ -79,21 +78,17 @@ func newStdoutTraceExporter(_ context.Context, _ config) (trace.SpanExporter, er
 // newGRPCExporter creates a new gRPC exporter for OpenTelemetry traces.
 // https://opentelemetry.io/docs/languages/go/exporters/#otlp-traces-over-grpc
 func newGRPCTraceExporter(ctx context.Context, c config) (trace.SpanExporter, error) {
-	return otlptrace.New(ctx,
-		otlptracegrpc.NewClient(
-			otlptracegrpc.WithEndpoint(c.Endpoint),
-			otlptracegrpc.WithHeaders(c.Headers),
-		),
+	return otlptracegrpc.New(ctx,
+		otlptracegrpc.WithEndpoint(c.Endpoint),
+		otlptracegrpc.WithHeaders(c.Headers),
 	)
 }
 
 // newHTTPExporter creates a new HTTP exporter for OpenTelemetry traces.
 // https://opentelemetry.io/docs/languages/go/exporters/#otlp-traces-over-http
 func newHTTPTraceExporter(ctx context.Context, c config) (trace.SpanExporter, error) {
-	return otlptrace.New(ctx,
-		otlptracehttp.NewClient(
-			otlptracehttp.WithEndpoint(c.Endpoint),
-			otlptracehttp.WithHeaders(c.Headers),
-		),
+	return otlptracehttp.New(ctx,
+		otlptracehttp.WithEndpoint(c.Endpoint),
+		otlptracehttp.WithHeaders(c.Headers),
 	)
 }


### PR DESCRIPTION
- Use `otlptracegrpc.New()` and `otlptracehttp.New()` to create trace exporters directly, eliminate unnecessary client wrapper layer.
- Move `go.opentelemetry.io/otel/exporters/otlp/otlptrace` to indirect dependency in `go.mod` file.