### PR TITLE
ci: ignore OpenTelemetry go denpendencies in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,5 @@ updates:
       - "dependencies 📦"
       - "CI/CD ⚙️"
     target-branch: "main"
+    ignore:
+      - dependency-name: "go.opentelemetry.io/*"


### PR DESCRIPTION
Ignore all OpenTelemetry go dependencies `go.opentelemetry.io/*` in Dependabot to prevent PR flooding.

Add `ignore`[^1] option to `dependabot.yml` config file.

> related issue: #519

[^1]: [Dependabot options reference - `ignore`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#ignore--)