### PR TITLE
feat: add otel-related configuration support

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -45,6 +45,7 @@ type appConfig struct {
 	Redis    RedisConfig    `ini:"redis"`
 	Sentry   SentryConfig   `ini:"sentry"`
 	Logger   LoggerConfig   `ini:"log"`
+	Otel     OtelConfig     `ini:"otel"`
 	WebAuthn WebAuthnConfig `ini:"webauthn"`
 	SMTP     SMTPConfig     `ini:"smtp"`
 }
@@ -93,6 +94,14 @@ type LoggerConfig struct {
 	Bark     string `ini:"bark"`     // bark token
 	Telegram string `ini:"telegram"` // telegram bot token
 	Newrelic string `ini:"newrelic"` // newrelic api key
+}
+
+// OtelConfig is the OpenTelemetry configuration.
+type OtelConfig struct {
+	ClientType string `ini:"clientType"` // client type, used to detect if OpenTelemetry is enabled
+	Endpoint   string `ini:"endpoint"`
+	Header     string `ini:"header"` // header name for authentication
+	Token      string `ini:"token"`  // token or key for authentication
 }
 
 // WebAuthnConfig is the WebAuthn configuration.

--- a/src/config/example.ini
+++ b/src/config/example.ini
@@ -34,6 +34,12 @@ level = INFO      # log level: DEBUG, INFO, WARN, ERROR  (default: INFO)
 route = route.log # log path for route request           (default use stdout if empty)
 app   = os.Stdout # log writer: bark, telegram, newrelic (default: os.Stdout)
 
+[otel]
+clientType = grpc           # client type: grpc, http, stdout (disable OpenTelemetry as empty)
+endpoint   = localhost:4317 # endpoint for OpenTelemetry      (default: localhost:4317)
+header     = api-key
+token      = xxxxxxxxxxxxxx
+
 [webauthn]
 rpID          = example.com
 rpDisplayName = webauthn example


### PR DESCRIPTION
- Add `[otel]` section in `example.ini` with example values and comments.
- Define `OtelConfig` struct with **clientType**, **endpoint**, **header**, and **token** fields to hold OpenTelemetry configuration.
- Update `appConfig` struct to include `OtelConfig` as a field.