### PR TITLE
Add OpenTelemetry initialization in web server startup

### DIFF
--- a/src/cmd/web.go
+++ b/src/cmd/web.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Pengxn/go-xn/src/lib/webauthn"
 	"github.com/Pengxn/go-xn/src/model"
 	"github.com/Pengxn/go-xn/src/route"
+	"github.com/Pengxn/go-xn/src/util/otel"
 	slogger "github.com/Pengxn/go-xn/src/util/slog"
 )
 
@@ -61,6 +62,10 @@ func runWeb(ctx context.Context, c *cli.Command) error {
 	// Initialize the logger
 	ctx = context.WithValue(ctx, slogger.CtxVersionKey, version)
 	slogger.SetLogger(ctx, config.Config.Logger)
+
+	// Initialize OpenTelemetry
+	shutdown := otel.SetOtel(ctx, config.Config.Otel)
+	defer shutdown(ctx)
 
 	err := route.InitRoutes()
 	if err != nil {

--- a/src/util/otel/otel.go
+++ b/src/util/otel/otel.go
@@ -1,0 +1,43 @@
+package otel
+
+import (
+	"context"
+	"log/slog"
+
+	commonConfig "github.com/Pengxn/go-xn/src/config"
+)
+
+func SetOtel(ctx context.Context, c commonConfig.OtelConfig) func(ctx context.Context) {
+	// OpenTelemetry is disabled if ClientType is empty
+	if c.ClientType == "" {
+		slog.Debug("OpenTelemetry is disabled as clientType is empty")
+		return func(ctx context.Context) {}
+	}
+
+	cfg := NewConfig(
+		WithClientType(c.ClientType),
+		WithEndpoint(c.Endpoint),
+		WithHeaders(map[string]string{
+			c.Header: c.Token,
+		}))
+
+	// Initialize OpenTelemetry tracing
+	traceShutdown := InitTrace(ctx, cfg)
+
+	// Initialize OpenTelemetry metrics
+	metricShutdown := InitMetric(ctx, cfg)
+
+	// Initialize OpenTelemetry logging
+	_ = NewLogger(ctx, cfg)
+
+	return func(ctx context.Context) {
+		err := traceShutdown(ctx)
+		if err != nil {
+			slog.Error("failed to shutdown otel trace", slog.Any("error", err))
+		}
+		err = metricShutdown(ctx)
+		if err != nil {
+			slog.Error("failed to shutdown otel metric", slog.Any("error", err))
+		}
+	}
+}


### PR DESCRIPTION
- Initialize OpenTelemetry before starting the web server, and ensure proper shutdown on server exit.
- Use `otel.SetOtel` to set up tracing, metrics, and logging with custom config, and return a shutdown function.