### PR TITLE
refactor: pass context and server config to initialize routes

### DIFF
--- a/src/cmd/web.go
+++ b/src/cmd/web.go
@@ -67,7 +67,7 @@ func runWeb(ctx context.Context, c *cli.Command) error {
 	shutdown := otel.SetOtel(ctx, config.Config.Otel)
 	defer shutdown(ctx)
 
-	err := route.InitRoutes()
+	err := route.InitRoutes(ctx, config.Config.Server)
 	if err != nil {
 		log.Fatalln("fail to init routes", err)
 	}

--- a/src/route/route.go
+++ b/src/route/route.go
@@ -1,6 +1,8 @@
 package route
 
 import (
+	"context"
+
 	"github.com/gin-gonic/gin"
 
 	"github.com/Pengxn/go-xn/src/config"
@@ -9,9 +11,8 @@ import (
 )
 
 // InitRoutes initializes all routes.
-func InitRoutes() error {
-	serverConfig := config.Config.Server
-	if !serverConfig.Debug {
+func InitRoutes(ctx context.Context, c config.ServerConfig) error {
+	if !c.Debug {
 		gin.SetMode(gin.ReleaseMode)
 	}
 
@@ -25,7 +26,7 @@ func InitRoutes() error {
 	// Health check
 	g.GET("/health", func(c *gin.Context) { c.String(200, "ok") })
 
-	if serverConfig.Debug {
+	if c.Debug {
 		debugRoutes(g)
 	}
 	apiRoutes(g)
@@ -36,8 +37,8 @@ func InitRoutes() error {
 	staticRoutes(g)
 	articlesRoutes(g)
 
-	if serverConfig.TLS {
-		return g.RunTLS(":"+serverConfig.Port, serverConfig.CertFile, serverConfig.KeyFile)
+	if c.TLS {
+		return g.RunTLS(":"+c.Port, c.CertFile, c.KeyFile)
 	}
-	return g.Run(":" + serverConfig.Port)
+	return g.Run(":" + c.Port)
 }


### PR DESCRIPTION
- Update `InitRoutes` function signature to accept `context.Context` and `config.ServerConfig` arguments.
- Use param to initialize routes instead of relying on the global config variable.