### PR TITLE
Add `EnablePrometheus` option to enable metrics collection conditionally

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -98,13 +98,14 @@ type LoggerConfig struct {
 
 // OtelConfig is the OpenTelemetry configuration.
 type OtelConfig struct {
-	EnableTrace  bool   `ini:"trace"`      // enable OpenTelemetry tracing
-	EnableMetric bool   `ini:"metric"`     // enable OpenTelemetry metrics
-	EnableLog    bool   `ini:"log"`        // enable OpenTelemetry logging
-	ClientType   string `ini:"clientType"` // client type, used to determine the OpenTelemetry client
-	Endpoint     string `ini:"endpoint"`   // endpoint for OpenTelemetry, default: localhost:4317
-	Header       string `ini:"header"`     // header name for authentication
-	Token        string `ini:"token"`      // token or key for authentication
+	EnableTrace      bool   `ini:"trace"`      // enable OpenTelemetry tracing
+	EnableMetric     bool   `ini:"metric"`     // enable OpenTelemetry metrics
+	EnableLog        bool   `ini:"log"`        // enable OpenTelemetry logging
+	ClientType       string `ini:"clientType"` // client type, used to determine the OpenTelemetry client
+	Endpoint         string `ini:"endpoint"`   // endpoint for OpenTelemetry, default: localhost:4317
+	Header           string `ini:"header"`     // header name for authentication
+	Token            string `ini:"token"`      // token or key for authentication
+	EnablePrometheus bool   `ini:"prometheus"` // enable Prometheus metrics
 }
 
 // WebAuthnConfig is the WebAuthn configuration.

--- a/src/config/example.ini
+++ b/src/config/example.ini
@@ -42,6 +42,7 @@ clientType = grpc           # client type: grpc, http, stdout (disable OpenTelem
 endpoint   = localhost:4317 # endpoint for OpenTelemetry      (default: localhost:4317)
 header     = api-key
 token      = xxxxxxxxxxxxxx
+prometheus = false          # enable Prometheus metrics       (default: false)
 
 [webauthn]
 rpID          = example.com

--- a/src/route/others.go
+++ b/src/route/others.go
@@ -3,6 +3,7 @@ package route
 import (
 	"github.com/gin-gonic/gin"
 
+	"github.com/Pengxn/go-xn/src/config"
 	"github.com/Pengxn/go-xn/src/controller"
 	"github.com/Pengxn/go-xn/src/middleware"
 )
@@ -52,5 +53,7 @@ func othersRoutes(g *gin.Engine) {
 	g.Any("/bitcoin-alias", controller.BitcoinAliases)
 
 	// Metrics for Prometheus.
-	g.GET("/metrics", controller.PrometheusMetrics)
+	if config.Config.Otel.EnablePrometheus {
+		g.GET("/metrics", controller.PrometheusMetrics)
+	}
 }


### PR DESCRIPTION
- Add `EnablePrometheus` field to `OtelConfig` struct with **ini** tag and update `example.ini` to include `prometheus` config option (default is `false`).
- Enable Prometheus metrics collection and register `/metrics` endpoint via `config.Config.Otel.EnablePrometheus` config.