### PR TITLE
fix: correct dependabot ignore rule placement for OpenTelemetry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
     labels:
       - "dependencies 📦"
     target-branch: "main"
+    ignore:
+      - dependency-name: "go.opentelemetry.io/*"
+
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -19,5 +22,3 @@ updates:
       - "dependencies 📦"
       - "CI/CD ⚙️"
     target-branch: "main"
-    ignore:
-      - dependency-name: "go.opentelemetry.io/*"


### PR DESCRIPTION
The `ignore.dependency-name` option was misplaced under `github-actions` instead of `gomod` ecosystem in PR #522, causing it to be ineffective.
Fix it to ensure the intended `go.opentelemetry.io/*` dependencies are excluded from dependabot updates.

The mistake caused dependabot PR flood for OpenTelemetry updates.

> related PR #522