### PR TITLE
Bump go toolchain version to `1.25`

### DIFF
--- a/.github/workflows/test.docker.yml
+++ b/.github/workflows/test.docker.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Fetche Latest Image
         run: |
-          docker pull golang:1.24-alpine || true
+          docker pull golang:1.25-alpine || true
           docker pull alpine:latest || true
 
       - name: Setup QEMU

--- a/.github/workflows/test.linux.yml
+++ b/.github/workflows/test.linux.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
           cache: false
 
       - name: Set environment variables

--- a/.github/workflows/test.macos.yml
+++ b/.github/workflows/test.macos.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
           cache: false
 
       - name: Set environment variables

--- a/.github/workflows/test.windows.yml
+++ b/.github/workflows/test.windows.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
           cache: false
 
       - name: Set environment variables

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 # ENV GOPROXY https://goproxy.cn,direct
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Pengxn/go-xn
 
-go 1.24
+go 1.25
 
 tool (
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-//go:build go1.24
+//go:build go1.25
 
 // Copyright 2020 The Go-xn Authors. All rights reserved.
 // Use of this source code is governed by a Zlib license


### PR DESCRIPTION
- Upgrade go toolchain version to `1.25` in go.mod file.
- Bump go version to `1.25.x` for GitHub Actions.
- Update go build constraint version to `//go:build go1.25`.
- Update `golang` build image tag to `1.25-alpine`.