### PR TITLE
ci: pin windows runner to `windows-2022` to fix missing iscc

### DIFF
--- a/.github/workflows/test.windows.yml
+++ b/.github/workflows/test.windows.yml
@@ -3,7 +3,7 @@ on: workflow_call
 jobs:
   test-windows:
     name: Test on Windows
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
> The default windows-latest label was migrate from Windows Server 2022 to Windows Server 2025, and the Inno Setup was removed in Windows Server 2025.

---

Pin windows runner to `windows-2022` label to fix failed windows ci build due to missing iscc.

> refer to issue #588 and [Windows2022 images](https://github.com/actions/runner-images/blob/b99fd57b68439ba9168a076f855c3097a1c63265/images/windows/Windows2022-Readme.md#tools)