### PR TITLE
Update windows runner to `windows-latest`

### DIFF
--- a/.github/workflows/test.windows.yml
+++ b/.github/workflows/test.windows.yml
@@ -39,10 +39,6 @@ jobs:
           name: ${{ env.GOOS }}-${{ env.GOARCH }}
           path: build/
 
-      - name: Install Inno Setup
-        run: |
-          winget install -e --id JRSoftware.InnoSetup --accept-source-agreements
-
       - name: Build Inno Setup Installer
         run: |
           iscc script/windows/go-xn.iss


### PR DESCRIPTION
> related PR: #589

Update windows runner to `windows-latest`, because InnoSetup was built-in on windows runner image.

refer to the following links:
- [`actions/runner-images` PR #12947](https://github.com/actions/runner-images/issues/12947#issuecomment-3416540769)
- [Windows Server 2025 (20251014) Image #Tools](https://github.com/actions/runner-images/blob/releases/win25/20251014/images/windows/Windows2025-Readme.md#tools)