### PR TITLE
Add GitHub OAuth2 configuration support

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -47,6 +47,7 @@ type appConfig struct {
 	Logger   LoggerConfig   `ini:"log"`
 	Otel     OtelConfig     `ini:"otel"`
 	WebAuthn WebAuthnConfig `ini:"webauthn"`
+	OAuth2   OAuth2Config   `ini:"oauth2"`
 	SMTP     SMTPConfig     `ini:"smtp"`
 }
 
@@ -114,6 +115,12 @@ type WebAuthnConfig struct {
 	RPID          string   `ini:"rpID"`
 	RPDisplayName string   `ini:"rpDisplayName"`
 	RPOrigins     []string `ini:"rpOrigins"`
+}
+
+// OAuth2Config is the OAuth2 configuration.
+type OAuth2Config struct {
+	GithubClientID     string `ini:"githubClientID"`
+	GithubClientSecret string `ini:"githubClientSecret"`
 }
 
 // SMTPConfig is the mail SMTP configuration.

--- a/src/config/example.ini
+++ b/src/config/example.ini
@@ -50,6 +50,10 @@ rpID          = example.com
 rpDisplayName = webauthn example
 rpOrigins     = https://example.com, https://example.cn, http://test.example.com
 
+[oauth2]
+githubClientID     =                           # github oauth2 client id     (empty to disable github oauth2)
+githubClientSecret = your_github_client_secret # github oauth2 client secret (required if githubClientID is not empty)
+
 [smtp]
 host     = smtp.example.com # smtp server host
 port     = 465              # smtp server port


### PR DESCRIPTION
Add `OAuth2Config` struct with GitHub client ID and secret fields to enable GitHub OAuth2 authentication.
Update `example.ini` with corresponding configuration section and related comments.