### PR TITLE
Set otel text map propagators for distributed tracing

### DIFF
--- a/src/util/otel/otel.go
+++ b/src/util/otel/otel.go
@@ -5,6 +5,8 @@ import (
 	"log/slog"
 
 	commonConfig "github.com/Pengxn/go-xn/src/config"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 )
 
 func SetOtel(ctx context.Context, c commonConfig.OtelConfig) func(ctx context.Context) {
@@ -22,6 +24,13 @@ func SetOtel(ctx context.Context, c commonConfig.OtelConfig) func(ctx context.Co
 		}))
 
 	shutdown := []func(context.Context){}
+
+	// Enable and initialize OpenTelemetry propagator
+	prop := propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{}, // W3C Trace Context propagator
+		propagation.Baggage{},      // W3C Baggage propagator
+	)
+	otel.SetTextMapPropagator(prop)
 
 	// Enable and initialize OpenTelemetry tracing
 	if c.EnableTrace {


### PR DESCRIPTION
Initialize composite propagator with W3C Trace Context [^1] and W3C Baggage [^2], and set it as the global propagator for distributed tracing [^3].

[^1]: [W3C Trace Context](https://www.w3.org/TR/trace-context/)
[^2]: [W3C Propagation format for distributed context: Baggage](https://www.w3.org/TR/baggage/)
[^3]: [OpenTelemetry/Go/Instrumentation: Propagators and Context](https://opentelemetry.io/docs/languages/go/instrumentation/#propagators-and-context)