### PR TITLE
Update Makefile `generate` target to use `internal` path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ clean:
 	fi;
 
 generate:
-	@rm -rf src/rpc/proto/*.pb.go
+	@rm -rf internal/rpc/proto/*.pb.go
 	@go generate ./...
 
 cover: test


### PR DESCRIPTION
Update the `generate` target to reference the new `internal` path instead of the old `src` path.

> related issue: #731