### PR TITLE
Bump go-github to `v88` and adapt to `NewClient` API change

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/go-sql-driver/mysql v1.10.0
 	github.com/go-webauthn/webauthn v0.17.4
 	github.com/golang-jwt/jwt/v5 v5.3.1
-	github.com/google/go-github/v84 v84.0.0
+	github.com/google/go-github/v88 v88.0.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/feeds v1.2.0
 	github.com/lib/pq v1.12.3

--- a/internal/lib/github/github.go
+++ b/internal/lib/github/github.go
@@ -7,7 +7,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/google/go-github/v84/github"
+	"github.com/google/go-github/v88/github"
 )
 
 var (

--- a/internal/lib/github/github.go
+++ b/internal/lib/github/github.go
@@ -22,7 +22,10 @@ var (
 //
 // [GitHub Flavored Markdown Spec]: https://github.github.com/gfm/#gfm-overview
 func Render(text string) (string, error) {
-	client := github.NewClient(nil)
+	client, err := github.NewClient()
+	if err != nil {
+		return "", err
+	}
 
 	// API doc url: https://docs.github.com/en/rest/markdown/markdown
 	res, _, err := client.Markdown.Render(context.Background(), text, &github.MarkdownOptions{
@@ -40,7 +43,10 @@ func Render(text string) (string, error) {
 // It requires the owner and repo name of the repository.
 // The asset link is the download URL of the asset file for the current os and arch.
 func GetLatestAssetLink() (string, error) {
-	client := github.NewClient(nil)
+	client, err := github.NewClient()
+	if err != nil {
+		return "", err
+	}
 
 	// API doc url: https://docs.github.com/en/rest/releases/releases#get-the-latest-release
 	rel, _, err := client.Repositories.GetLatestRelease(context.Background(), defaultOwner, defaultRepo)
@@ -79,7 +85,11 @@ func GetNightlyLink() (string, error) {
 //
 // But it requires authentication with `actions:read` scope to access the archived artifacts links.
 func GetActionsArtifactLink() (string, string, error) {
-	client := github.NewClient(nil)
+	client, err := github.NewClient()
+	if err != nil {
+		return "", "", err
+	}
+
 	ctx := context.Background()
 
 	// Get the latest workflow run from list of workflow runs.


### PR DESCRIPTION
- Bumps `github.com/google/go-github/v84` to `github.com/google/go-github/v88`.
  > Changelog: [`v85`], [`v86`], [`v87`], [`v88`]
- Adapt to `NewClient` API change in go-github `v88`.
  `NewClient` now uses a functional options pattern and returns `(*Client, error)` instead of `*Client` alone.
  Remove the `nil` argument and handle the new error return value at all call sites.
  > refer to https://github.com/google/go-github/pull/4201

[`v85`]: https://github.com/google/go-github/releases/tag/v85.0.0
[`v86`]: https://github.com/google/go-github/releases/tag/v86.0.0
[`v87`]: https://github.com/google/go-github/releases/tag/v87.0.0
[`v88`]: https://github.com/google/go-github/releases/tag/v88.0.0