### PR TITLE
Use provider shutdown for otel metrics and traces

### DIFF
--- a/internal/util/otel/metric.go
+++ b/internal/util/otel/metric.go
@@ -36,23 +36,23 @@ func InitMetric(ctx context.Context, c *config) func(context.Context) error {
 
 	exporter, err := metricExporter(ctx, *c)
 	if err != nil {
-		log.Fatal("failed to create metric exporter: ", err)
+		log.Fatalf("failed to create metric exporter: %s", err)
 	}
 
 	// Create new resource
 	resources, err := commonResource(ctx)
 	if err != nil {
-		log.Fatal("failed to create resource: ", err)
+		log.Fatalf("failed to create resource: %s", err)
 	}
 
-	otel.SetMeterProvider(
-		metric.NewMeterProvider(
-			metric.WithReader(metric.NewPeriodicReader(exporter)),
-			metric.WithResource(resources),
-		),
+	mp := metric.NewMeterProvider(
+		metric.WithReader(metric.NewPeriodicReader(exporter)),
+		metric.WithResource(resources),
 	)
+	// Set the global OpenTelemetry meter provider
+	otel.SetMeterProvider(mp)
 
-	return exporter.Shutdown
+	return mp.Shutdown
 }
 
 // metricFunc is a function that creates an OpenTelemetry exporter.

--- a/internal/util/otel/trace.go
+++ b/internal/util/otel/trace.go
@@ -33,34 +33,26 @@ func InitTrace(ctx context.Context, c *config) func(context.Context) error {
 			return nil, nil // nil as no-op exporter
 		}
 	}
-
-	return initOTELTracer(ctx, *c, exporterFn)
-}
-
-// initOTELTracer initializes the OpenTelemetry tracer with the given client.
-func initOTELTracer(ctx context.Context, c config, fn exporterFunc) func(context.Context) error {
-	// create the exporter
-	exporter, err := fn(ctx, c)
+	exporter, err := exporterFn(ctx, *c)
 	if err != nil {
-		log.Fatalf("failed to create tracer exporter: %s", err)
+		log.Fatalf("failed to create trace exporter: %s", err)
 	}
 
-	// create the resource
+	// Create new resource
 	resources, err := commonResource(ctx)
 	if err != nil {
-		log.Fatalf("failed to set resources: %s", err)
+		log.Fatalf("failed to create resource: %s", err)
 	}
 
-	// set the global OpenTelemetry tracer provider
-	otel.SetTracerProvider(
-		trace.NewTracerProvider(
-			trace.WithSampler(trace.AlwaysSample()),
-			trace.WithBatcher(exporter),
-			trace.WithResource(resources),
-		),
+	tp := trace.NewTracerProvider(
+		trace.WithSampler(trace.AlwaysSample()),
+		trace.WithBatcher(exporter),
+		trace.WithResource(resources),
 	)
+	// set the global OpenTelemetry tracer provider
+	otel.SetTracerProvider(tp)
 
-	return exporter.Shutdown
+	return tp.Shutdown
 }
 
 // exporterFunc is a function type that takes a context and config,


### PR DESCRIPTION
> Shut down OpenTelemetry metric and trace pipelines through their SDK providers instead of closing exporters directly.

- Use `MeterProvider.Shutdown` to stop the periodic reader, flush pending metrics, and close the exporter.
- Use `TracerProvider.Shutdown` to flush batched spans and close the exporter.
- Inline tracer provider setup into `InitTrace` function.